### PR TITLE
fix: silence test logs

### DIFF
--- a/src/lib/logger.go
+++ b/src/lib/logger.go
@@ -3,8 +3,10 @@ package lib
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"os"
+	"sync"
 	"time"
 )
 
@@ -41,6 +43,7 @@ func (l LogLevel) String() string {
 type Logger struct {
 	component string
 	level     LogLevel
+	writer    io.Writer
 }
 
 // LogEntry represents a structured log entry
@@ -57,12 +60,41 @@ func NewLogger(component string) *Logger {
 	return &Logger{
 		component: component,
 		level:     INFO,
+		writer:    getDefaultWriter(),
 	}
+}
+
+var (
+	defaultWriter    io.Writer = os.Stderr
+	defaultWriterMux sync.RWMutex
+)
+
+func getDefaultWriter() io.Writer {
+	defaultWriterMux.RLock()
+	defer defaultWriterMux.RUnlock()
+	return defaultWriter
+}
+
+func setDefaultWriter(writer io.Writer) {
+	if writer == nil {
+		writer = io.Discard
+	}
+	defaultWriterMux.Lock()
+	defer defaultWriterMux.Unlock()
+	defaultWriter = writer
 }
 
 // SetLevel sets the minimum log level
 func (l *Logger) SetLevel(level LogLevel) {
 	l.level = level
+}
+
+// SetOutput sets the destination writer for this logger instance
+func (l *Logger) SetOutput(writer io.Writer) {
+	if writer == nil {
+		writer = io.Discard
+	}
+	l.writer = writer
 }
 
 // Debug logs a debug message with optional context
@@ -123,8 +155,12 @@ func (l *Logger) log(level LogLevel, message string, context ...map[string]inter
 		return
 	}
 
-	// Write to stderr for structured logging
-	fmt.Fprintln(os.Stderr, string(jsonData))
+	// Write to configured destination for structured logging
+	writer := l.writer
+	if writer == nil {
+		writer = getDefaultWriter()
+	}
+	fmt.Fprintln(writer, string(jsonData))
 }
 
 // WithContext creates a convenience function for logging with common context
@@ -140,6 +176,12 @@ var globalLogger = NewLogger("cc-dailyuse-bar")
 // SetGlobalLevel sets the global logger level
 func SetGlobalLevel(level LogLevel) {
 	globalLogger.SetLevel(level)
+}
+
+// SetGlobalOutput sets the output writer for global logging and future loggers
+func SetGlobalOutput(writer io.Writer) {
+	setDefaultWriter(writer)
+	globalLogger.SetOutput(writer)
 }
 
 // Debug logs using the global logger

--- a/src/services/main_test.go
+++ b/src/services/main_test.go
@@ -1,0 +1,16 @@
+package services
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"cc-dailyuse-bar/src/lib"
+)
+
+func TestMain(m *testing.M) {
+	lib.SetGlobalOutput(io.Discard)
+	code := m.Run()
+	lib.SetGlobalOutput(os.Stderr)
+	os.Exit(code)
+}

--- a/src/services/main_test.go
+++ b/src/services/main_test.go
@@ -1,16 +1,12 @@
 package services
 
 import (
-	"io"
 	"os"
 	"testing"
 
-	"cc-dailyuse-bar/src/lib"
+	"cc-dailyuse-bar/tests/testhelpers"
 )
 
 func TestMain(m *testing.M) {
-	lib.SetGlobalOutput(io.Discard)
-	code := m.Run()
-	lib.SetGlobalOutput(os.Stderr)
-	os.Exit(code)
+	os.Exit(testhelpers.RunSilenced(m))
 }

--- a/tests/contract/main_test.go
+++ b/tests/contract/main_test.go
@@ -1,0 +1,16 @@
+package contract
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"cc-dailyuse-bar/src/lib"
+)
+
+func TestMain(m *testing.M) {
+	lib.SetGlobalOutput(io.Discard)
+	code := m.Run()
+	lib.SetGlobalOutput(os.Stderr)
+	os.Exit(code)
+}

--- a/tests/contract/main_test.go
+++ b/tests/contract/main_test.go
@@ -1,16 +1,12 @@
 package contract
 
 import (
-	"io"
 	"os"
 	"testing"
 
-	"cc-dailyuse-bar/src/lib"
+	"cc-dailyuse-bar/tests/testhelpers"
 )
 
 func TestMain(m *testing.M) {
-	lib.SetGlobalOutput(io.Discard)
-	code := m.Run()
-	lib.SetGlobalOutput(os.Stderr)
-	os.Exit(code)
+	os.Exit(testhelpers.RunSilenced(m))
 }

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -1,0 +1,16 @@
+package integration
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"cc-dailyuse-bar/src/lib"
+)
+
+func TestMain(m *testing.M) {
+	lib.SetGlobalOutput(io.Discard)
+	code := m.Run()
+	lib.SetGlobalOutput(os.Stderr)
+	os.Exit(code)
+}

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -1,16 +1,12 @@
 package integration
 
 import (
-	"io"
 	"os"
 	"testing"
 
-	"cc-dailyuse-bar/src/lib"
+	"cc-dailyuse-bar/tests/testhelpers"
 )
 
 func TestMain(m *testing.M) {
-	lib.SetGlobalOutput(io.Discard)
-	code := m.Run()
-	lib.SetGlobalOutput(os.Stderr)
-	os.Exit(code)
+	os.Exit(testhelpers.RunSilenced(m))
 }

--- a/tests/testhelpers/logging.go
+++ b/tests/testhelpers/logging.go
@@ -1,0 +1,18 @@
+package testhelpers
+
+import (
+	"io"
+	"testing"
+
+	"cc-dailyuse-bar/src/lib"
+)
+
+// RunSilenced executes the provided test suite with logging redirected to io.Discard.
+// It restores the previous global logger output before returning.
+func RunSilenced(m *testing.M) int {
+	original := lib.GetGlobalOutput()
+	lib.SetGlobalOutput(io.Discard)
+	code := m.Run()
+	lib.SetGlobalOutput(original)
+	return code
+}

--- a/tests/unit/main_test.go
+++ b/tests/unit/main_test.go
@@ -1,16 +1,12 @@
 package unit
 
 import (
-	"io"
 	"os"
 	"testing"
 
-	"cc-dailyuse-bar/src/lib"
+	"cc-dailyuse-bar/tests/testhelpers"
 )
 
 func TestMain(m *testing.M) {
-	lib.SetGlobalOutput(io.Discard)
-	code := m.Run()
-	lib.SetGlobalOutput(os.Stderr)
-	os.Exit(code)
+	os.Exit(testhelpers.RunSilenced(m))
 }

--- a/tests/unit/main_test.go
+++ b/tests/unit/main_test.go
@@ -1,0 +1,16 @@
+package unit
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"cc-dailyuse-bar/src/lib"
+)
+
+func TestMain(m *testing.M) {
+	lib.SetGlobalOutput(io.Discard)
+	code := m.Run()
+	lib.SetGlobalOutput(os.Stderr)
+	os.Exit(code)
+}


### PR DESCRIPTION
Logs are currently pretty verbose:

```
=== RUN   TestGlobalTemplateFunctions/ExecuteTemplate_-_invalid
{"context":{"error":"template: display:1: unclosed action","template":"Hello {{.Name"},"timestamp":"2025-09-17T17:56:59Z","level":"ERROR","component":"template","message":"Template parsing failed"}
{"context":{"error":"template: validation:1: unclosed action","template":"Hello {{.Name"},"timestamp":"2025-09-17T17:56:59Z","level":"WARN","component":"template","message":"Template validation failed"}
{"context":{"error":"template: display:1: unclosed action","template":"Hello {{.Name"},"timestamp":"2025-09-17T17:56:59Z","level":"ERROR","component":"template","message":"Template parsing failed"}
{"context":{"default":"Default","error":"[TEMPLATE_ERROR] failed to parse template: template: display:1: unclosed action","template":"Hello {{.Name"},"timestamp":"2025-09-17T17:56:59Z","level":"WARN","component":"template","message":"Template execution failed, using default"}
```

This fixes that