### PR TITLE
test: fix concurrent access test by priming cache

### DIFF
--- a/src/models/usage_state_test.go
+++ b/src/models/usage_state_test.go
@@ -239,7 +239,6 @@ func TestUsageState_ConcurrentAccess(t *testing.T) {
 	expectedStatus := state.Status // Should be Yellow since 7.5 > 5.0 but < 10.0
 
 	// Simulate concurrent reads (no writes to avoid data races)
-	done := make(chan bool, 10)
 	var wg sync.WaitGroup
 	wg.Add(10)
 
@@ -252,15 +251,11 @@ func TestUsageState_ConcurrentAccess(t *testing.T) {
 			assert.Equal(t, expectedStatus, state.Status)
 			assert.True(t, state.Status >= Green && state.Status <= Red)
 			
-			done <- true
 		}(i)
 	}
 
 	// Wait for all goroutines to complete
 	wg.Wait()
-	for i := 0; i < 10; i++ {
-		<-done
-	}
 
 	// Final verification
 	assert.Equal(t, Yellow, state.Status)

--- a/src/services/usage_service_test.go
+++ b/src/services/usage_service_test.go
@@ -480,7 +480,6 @@ func TestUsageService_ConcurrentAccess(t *testing.T) {
 	service.state.DailyCost = 5.0
 
 	// Test concurrent reads of cached data
-	done := make(chan bool, 10)
 	var wg sync.WaitGroup
 	wg.Add(10)
 
@@ -498,15 +497,11 @@ func TestUsageService_ConcurrentAccess(t *testing.T) {
 			assert.Equal(t, 100, state.DailyCount)
 			assert.Equal(t, 5.0, state.DailyCost)
 
-			done <- true
 		}(i)
 	}
 
 	// Wait for all goroutines to complete
 	wg.Wait()
-	for i := 0; i < 10; i++ {
-		<-done
-	}
 }
 
 func TestUsageService_EdgeCases(t *testing.T) {

--- a/src/services/usage_service_test.go
+++ b/src/services/usage_service_test.go
@@ -470,6 +470,12 @@ echo '` + string(jsonData) + `'`
 func TestUsageService_ConcurrentAccess(t *testing.T) {
 	service := newTestUsageService()
 
+	// Prime the cache so GetDailyUsage() returns in-memory data instead of
+	// shelling out to the real ccusage binary which is not present in CI.
+	service.cacheWindow = time.Hour
+	service.lastQuery = time.Now()
+	service.state.IsAvailable = true
+
 	// Test concurrent access to state
 	done := make(chan bool, 10)
 


### PR DESCRIPTION
Ensure TestUsageService_ConcurrentAccess uses cached data instead of attempting to call ccusage binary which is not available in CI environment.

🤖 Generated with [Claude Code](https://claude.ai/code)