### PR TITLE
fix: ensure polling stop signals reach goroutines

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -258,5 +258,6 @@ func onExit() {
 	// Ensure background goroutines stop cleanly
 	if usageService != nil {
 		usageService.StopPolling()
+		usageService.StopDailyResetMonitor()
 	}
 }

--- a/src/services/usage_service.go
+++ b/src/services/usage_service.go
@@ -442,15 +442,8 @@ func (us *UsageService) StopPolling() {
 		us.ticker = nil
 	}
 
-	var pollStopChan, resetStopChan chan struct{}
-	if us.pollStopChan != nil {
-		pollStopChan = us.pollStopChan
-		us.pollStopChan = make(chan struct{})
-	}
-	if us.resetStopChan != nil {
-		resetStopChan = us.resetStopChan
-		us.resetStopChan = make(chan struct{})
-	}
+	pollStopChan := us.replaceStopChan(&us.pollStopChan)
+	resetStopChan := us.replaceStopChan(&us.resetStopChan)
 	us.mutex.Unlock()
 
 	if pollStopChan != nil {
@@ -461,6 +454,14 @@ func (us *UsageService) StopPolling() {
 	}
 
 	us.logger.Info("Usage polling stopped")
+}
+
+func (us *UsageService) replaceStopChan(chPtr *chan struct{}) chan struct{} {
+	oldChan := *chPtr
+	if oldChan != nil {
+		*chPtr = make(chan struct{})
+	}
+	return oldChan
 }
 
 // pollingLoop runs the polling loop in a goroutine

--- a/src/services/usage_service.go
+++ b/src/services/usage_service.go
@@ -434,26 +434,38 @@ func (us *UsageService) StartPolling(intervalSeconds int, callback func(*models.
 	return nil
 }
 
-// StopPolling stops the polling timer
+// StopPolling stops the polling timer. It does NOT stop the daily reset
+// monitor — call StopDailyResetMonitor for that. Splitting them lets callers
+// restart polling (StartPolling internally calls StopPolling) without tearing
+// down a running midnight monitor.
 func (us *UsageService) StopPolling() {
 	us.mutex.Lock()
 	if us.ticker != nil {
 		us.ticker.Stop()
 		us.ticker = nil
 	}
-
 	pollStopChan := us.replaceStopChan(&us.pollStopChan)
-	resetStopChan := us.replaceStopChan(&us.resetStopChan)
 	us.mutex.Unlock()
 
 	if pollStopChan != nil {
 		close(pollStopChan)
 	}
+
+	us.logger.Info("Usage polling stopped")
+}
+
+// StopDailyResetMonitor stops the midnight detection goroutine started by
+// StartDailyResetMonitor. Idempotent.
+func (us *UsageService) StopDailyResetMonitor() {
+	us.mutex.Lock()
+	resetStopChan := us.replaceStopChan(&us.resetStopChan)
+	us.mutex.Unlock()
+
 	if resetStopChan != nil {
 		close(resetStopChan)
 	}
 
-	us.logger.Info("Usage polling stopped")
+	us.logger.Info("Daily reset monitor stopped")
 }
 
 func (us *UsageService) replaceStopChan(chPtr *chan struct{}) chan struct{} {

--- a/src/services/usage_service.go
+++ b/src/services/usage_service.go
@@ -418,18 +418,18 @@ func (us *UsageService) StartPolling(intervalSeconds int, callback func(*models.
 
 	ticker := time.NewTicker(time.Duration(intervalSeconds) * time.Second)
 
-	// Create ticker and assign callback atomically with mutex protection
+	// Launch the goroutine while still holding the mutex so a concurrent
+	// StopPolling() cannot close the captured stop channel before the loop
+	// observes it.
 	us.mutex.Lock()
 	us.updateCallback = callback
 	us.ticker = ticker
-	stopChan := us.pollStopChan
+	go us.pollingLoop(ticker, us.pollStopChan)
 	us.mutex.Unlock()
 
 	us.logger.Info("Starting usage polling", map[string]interface{}{
 		"intervalSeconds": intervalSeconds,
 	})
-
-	go us.pollingLoop(ticker, stopChan)
 
 	return nil
 }
@@ -499,11 +499,12 @@ func (us *UsageService) pollingLoop(ticker *time.Ticker, stopChan <-chan struct{
 
 // T031: Daily reset scheduler with midnight detection
 func (us *UsageService) StartDailyResetMonitor() {
+	// Launch under the read lock so StopPolling cannot replace/close the
+	// captured stop channel between the read and the goroutine start.
 	us.mutex.RLock()
-	stopChan := us.resetStopChan
+	go us.dailyResetLoop(us.resetStopChan)
 	us.mutex.RUnlock()
 
-	go us.dailyResetLoop(stopChan)
 	us.logger.Info("Daily reset monitor started")
 }
 

--- a/src/services/usage_service_test.go
+++ b/src/services/usage_service_test.go
@@ -5,20 +5,46 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
 
+	"cc-dailyuse-bar/src/models"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"cc-dailyuse-bar/src/models"
 )
 
 // Helper function to create a usage service with default config
 func newTestUsageService() *UsageService {
 	config := models.ConfigDefaults()
 	return NewUsageService(config)
+}
+
+// waitForStableGoroutineCount polls runtime.NumGoroutine() until it returns
+// the same value across `stableFor` consecutive samples (10ms apart) or
+// `timeout` elapses, then returns that value. Used to capture a clean
+// "idle" baseline that isn't polluted by goroutines from earlier tests
+// still in the process of exiting.
+func waitForStableGoroutineCount(t *testing.T, stableFor, timeout time.Duration) int {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	last := runtime.NumGoroutine()
+	stableSince := time.Now()
+	for time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+		now := runtime.NumGoroutine()
+		if now != last {
+			last = now
+			stableSince = time.Now()
+			continue
+		}
+		if time.Since(stableSince) >= stableFor {
+			return last
+		}
+	}
+	return last
 }
 
 func TestNewUsageService(t *testing.T) {
@@ -283,6 +309,11 @@ func TestUsageService_StartDailyResetMonitor(t *testing.T) {
 // StartPolling produces a working second polling loop. Regression test for the
 // race where the second goroutine could observe a closed stop channel and exit
 // before its first tick.
+//
+// To avoid the second-phase assertion being satisfied by a leaked first
+// goroutine, each phase uses its own callback/counter, and we confirm the
+// first phase's counter stops incrementing after StopPolling before starting
+// the second phase.
 func TestUsageService_PollingRestart(t *testing.T) {
 	service := newTestUsageService()
 	service.StopPolling()
@@ -303,55 +334,121 @@ func TestUsageService_PollingRestart(t *testing.T) {
 		[]byte("#!/bin/bash\necho '"+string(jsonData)+"'"), 0o755))
 	service.ccusagePath = scriptPath
 
-	var mu sync.Mutex
-	var calls int
-	cb := func(_ *models.UsageState) {
-		mu.Lock()
-		calls++
-		mu.Unlock()
+	makeCounter := func() (cb func(*models.UsageState), get func() int) {
+		var mu sync.Mutex
+		var n int
+		cb = func(_ *models.UsageState) {
+			mu.Lock()
+			n++
+			mu.Unlock()
+		}
+		get = func() int {
+			mu.Lock()
+			defer mu.Unlock()
+			return n
+		}
+		return
 	}
 
-	require.NoError(t, service.StartPolling(1, cb))
+	cb1, count1 := makeCounter()
+	require.NoError(t, service.StartPolling(1, cb1))
+	time.Sleep(1500 * time.Millisecond)
+	require.GreaterOrEqual(t, count1(), 1, "first polling loop should have fired before stop")
 	service.StopPolling()
 
-	require.NoError(t, service.StartPolling(1, cb))
+	// Confirm the first goroutine has actually stopped — no further callbacks
+	// for a brief settle window — so the second phase isn't satisfied by a
+	// leaked first loop.
+	frozen := count1()
+	time.Sleep(1200 * time.Millisecond)
+	require.Equal(t, frozen, count1(), "first polling loop should not fire after StopPolling")
+
+	cb2, count2 := makeCounter()
+	require.NoError(t, service.StartPolling(1, cb2))
 	defer service.StopPolling()
 
-	// Allow at least one tick from the restarted polling loop.
 	time.Sleep(1500 * time.Millisecond)
-
-	mu.Lock()
-	got := calls
-	mu.Unlock()
-	assert.GreaterOrEqual(t, got, 1, "restarted polling loop should fire at least once")
+	assert.GreaterOrEqual(t, count2(), 1, "restarted polling loop should fire at least once")
 }
 
 // TestUsageService_StopPollingTwice asserts that StopPolling is idempotent
 // even after channels have been swapped, guarding against double-close panics
-// in the channel-swap helper.
+// in the channel-swap helper. Also covers StopDailyResetMonitor for the same
+// reason.
 func TestUsageService_StopPollingTwice(t *testing.T) {
 	service := newTestUsageService()
 
 	require.NoError(t, service.StartPolling(1, nil))
 	service.StopPolling()
 	assert.NotPanics(t, func() { service.StopPolling() })
+
+	service.StartDailyResetMonitor()
+	service.StopDailyResetMonitor()
+	assert.NotPanics(t, func() { service.StopDailyResetMonitor() })
+}
+
+// TestUsageService_StartPollingDoesNotStopResetMonitor guards the bug where
+// StartPolling internally called StopPolling, and StopPolling closed both the
+// polling and reset channels — so restarting polling silently killed the
+// midnight monitor. Now StopPolling only touches the polling channel.
+func TestUsageService_StartPollingDoesNotStopResetMonitor(t *testing.T) {
+	service := newTestUsageService()
+	service.StopPolling()
+	service.StopDailyResetMonitor()
+
+	baseline := waitForStableGoroutineCount(t, 100*time.Millisecond, 1*time.Second)
+	service.StartDailyResetMonitor()
+	defer service.StopDailyResetMonitor()
+	require.Eventually(t, func() bool { return runtime.NumGoroutine() > baseline },
+		500*time.Millisecond, 10*time.Millisecond,
+		"reset monitor goroutine should be running")
+	withResetMonitor := runtime.NumGoroutine()
+
+	// Now (re)start polling. The reset monitor must survive.
+	require.NoError(t, service.StartPolling(1, nil))
+	defer service.StopPolling()
+
+	// Allow polling goroutine to spin up; we expect at least the reset monitor
+	// goroutine count to be retained, plus the new polling goroutine.
+	require.Eventually(t, func() bool { return runtime.NumGoroutine() >= withResetMonitor+1 },
+		500*time.Millisecond, 10*time.Millisecond,
+		"polling restart should not have killed the reset monitor goroutine")
 }
 
 // TestUsageService_DailyResetRestart verifies the daily reset monitor can be
-// stopped and restarted without deadlocking, exercising the same channel-swap
-// pattern as the polling loop.
+// stopped and restarted without deadlocking, and that the second start
+// actually launches a live goroutine. The dailyResetLoop has no externally
+// observable signal short of midnight, so liveness is asserted via the
+// runtime goroutine count rising above the idle baseline after a stop and
+// restart cycle — with a sleep after stop to let the first goroutine retire,
+// so the post-restart count would equal the idle baseline if the second
+// goroutine had observed a closed channel and exited immediately.
 func TestUsageService_DailyResetRestart(t *testing.T) {
 	service := newTestUsageService()
 	service.StopPolling()
+	service.StopDailyResetMonitor()
+
+	// Earlier tests can leave goroutines mid-exit; wait for the runtime to
+	// settle before sampling idle, otherwise idle is inflated by zombies that
+	// then retire mid-test and make our delta assertions look like regressions.
+	idle := waitForStableGoroutineCount(t, 100*time.Millisecond, 1*time.Second)
 
 	service.StartDailyResetMonitor()
-	service.StopPolling()
+	require.Eventually(t, func() bool { return runtime.NumGoroutine() > idle },
+		500*time.Millisecond, 10*time.Millisecond,
+		"first StartDailyResetMonitor should add a goroutine")
+
+	service.StopDailyResetMonitor()
+	// Give the first goroutine time to actually exit before we restart, so any
+	// elevated goroutine count after the second start is attributable to the
+	// second goroutine alone.
+	time.Sleep(150 * time.Millisecond)
 
 	service.StartDailyResetMonitor()
-	defer service.StopPolling()
-
-	// A short sleep is enough; we're checking lifecycle, not midnight detection.
-	time.Sleep(100 * time.Millisecond)
+	defer service.StopDailyResetMonitor()
+	require.Eventually(t, func() bool { return runtime.NumGoroutine() > idle },
+		500*time.Millisecond, 10*time.Millisecond,
+		"after stop+restart, goroutine count must exceed idle — proves the restarted loop didn't observe a closed channel and exit immediately")
 }
 
 func TestUsageService_UpdateWithRetry_NotAvailable(t *testing.T) {

--- a/src/services/usage_service_test.go
+++ b/src/services/usage_service_test.go
@@ -279,6 +279,81 @@ func TestUsageService_StartDailyResetMonitor(t *testing.T) {
 	service.StopPolling()
 }
 
+// TestUsageService_PollingRestart verifies that StartPolling -> StopPolling ->
+// StartPolling produces a working second polling loop. Regression test for the
+// race where the second goroutine could observe a closed stop channel and exit
+// before its first tick.
+func TestUsageService_PollingRestart(t *testing.T) {
+	service := newTestUsageService()
+	service.StopPolling()
+
+	// Point ccusage at a fast shim so updateWithRetry returns immediately and
+	// the callback fires within the test's wait window.
+	tempDir := t.TempDir()
+	scriptPath := filepath.Join(tempDir, "fake-ccusage")
+	today := time.Now().Format("2006-01-02")
+	resp := CCUsageResponse{
+		Daily: []CCUsageOutput{{Date: today, TotalTokens: 1, TotalCost: 0.01}},
+	}
+	resp.Totals.TotalTokens = 1
+	resp.Totals.TotalCost = 0.01
+	jsonData, err := json.Marshal(resp)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(scriptPath,
+		[]byte("#!/bin/bash\necho '"+string(jsonData)+"'"), 0o755))
+	service.ccusagePath = scriptPath
+
+	var mu sync.Mutex
+	var calls int
+	cb := func(_ *models.UsageState) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+	}
+
+	require.NoError(t, service.StartPolling(1, cb))
+	service.StopPolling()
+
+	require.NoError(t, service.StartPolling(1, cb))
+	defer service.StopPolling()
+
+	// Allow at least one tick from the restarted polling loop.
+	time.Sleep(1500 * time.Millisecond)
+
+	mu.Lock()
+	got := calls
+	mu.Unlock()
+	assert.GreaterOrEqual(t, got, 1, "restarted polling loop should fire at least once")
+}
+
+// TestUsageService_StopPollingTwice asserts that StopPolling is idempotent
+// even after channels have been swapped, guarding against double-close panics
+// in the channel-swap helper.
+func TestUsageService_StopPollingTwice(t *testing.T) {
+	service := newTestUsageService()
+
+	require.NoError(t, service.StartPolling(1, nil))
+	service.StopPolling()
+	assert.NotPanics(t, func() { service.StopPolling() })
+}
+
+// TestUsageService_DailyResetRestart verifies the daily reset monitor can be
+// stopped and restarted without deadlocking, exercising the same channel-swap
+// pattern as the polling loop.
+func TestUsageService_DailyResetRestart(t *testing.T) {
+	service := newTestUsageService()
+	service.StopPolling()
+
+	service.StartDailyResetMonitor()
+	service.StopPolling()
+
+	service.StartDailyResetMonitor()
+	defer service.StopPolling()
+
+	// A short sleep is enough; we're checking lifecycle, not midnight detection.
+	time.Sleep(100 * time.Millisecond)
+}
+
 func TestUsageService_UpdateWithRetry_NotAvailable(t *testing.T) {
 	service := newTestUsageService()
 


### PR DESCRIPTION
## Summary
- update usage polling to pass ticker and stop channel into the worker goroutines
- close existing stop channels when stopping and create fresh ones for future runs
- ensure the daily reset monitor also listens to the correct stop channel reference

## Testing
- go test ./src/lib ./src/models ./src/services ./src/internal/testhelpers

------
https://chatgpt.com/codex/tasks/task_e_68cb3957d0e483219a162d0b5376a36c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of background polling and daily reset monitoring so they stop and restart cleanly; shutdown now ensures both background processes are terminated.

* **Tests**
  * Added lifecycle and stability tests covering polling restart, idempotent stop calls, and reset-monitor stop/restart behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->