### PR TITLE
fix: throttle cache after ccusage command failure

### DIFF
--- a/src/services/usage_service.go
+++ b/src/services/usage_service.go
@@ -284,6 +284,7 @@ func (us *UsageService) performUpdateLocked(maxRetries int) (*models.UsageState,
 			if lastErr == nil {
 				lastErr = err
 			}
+			us.setUnknownStateLocked()
 			return us.getStateCopyLocked(), lastErr
 		}
 

--- a/src/services/usage_service.go
+++ b/src/services/usage_service.go
@@ -66,9 +66,12 @@ type CCUsageResponse struct {
 	} `json:"totals"`
 }
 
-// GetDailyUsage queries ccusage and returns current daily statistics
-// Returns cached data if last query was within cache window
-// Returns error if ccusage is unavailable or returns invalid data
+// GetDailyUsage queries ccusage and returns current daily statistics. Returns
+// cached data if the last query was within the cache window — including
+// cached *failure* states, so a sustained ccusage outage doesn't trigger one
+// invocation per call (the throttle this PR exists to provide). Cached
+// failures are returned with the original error so callers can distinguish
+// "throttled-from-failure" from "fresh success".
 func (us *UsageService) GetDailyUsage() (*models.UsageState, error) {
 	us.mutex.RLock()
 	if time.Since(us.lastQuery) < us.cacheWindow {
@@ -76,6 +79,9 @@ func (us *UsageService) GetDailyUsage() (*models.UsageState, error) {
 		// check-then-act races with concurrent writers.
 		stateCopy := *us.state
 		us.mutex.RUnlock()
+		if !stateCopy.IsAvailable {
+			return &stateCopy, lib.WrapError(errCCUsageUnavailable, lib.ErrCodeCCUsage, "serving cached ccusage failure state")
+		}
 		return &stateCopy, nil
 	}
 	us.mutex.RUnlock()
@@ -84,7 +90,11 @@ func (us *UsageService) GetDailyUsage() (*models.UsageState, error) {
 	defer us.mutex.Unlock()
 
 	if time.Since(us.lastQuery) < us.cacheWindow {
-		return us.getStateCopyLocked(), nil
+		state := us.getStateCopyLocked()
+		if !state.IsAvailable {
+			return state, lib.WrapError(errCCUsageUnavailable, lib.ErrCodeCCUsage, "serving cached ccusage failure state")
+		}
+		return state, nil
 	}
 
 	return us.performUpdateLocked(1)

--- a/src/services/usage_service.go
+++ b/src/services/usage_service.go
@@ -112,6 +112,14 @@ func cachedFailureError(cached error) error {
 	return lib.WrapError(errCCUsageUnavailable, lib.ErrCodeCCUsage, "serving cached ccusage failure state")
 }
 
+// newCCUsageUnavailableError wraps the bare sentinel with ErrCodeCCUsage so
+// callers using errors.As(*lib.AppError) see the structured type. The chain
+// preserves the sentinel, so errors.Is(err, errCCUsageUnavailable) still
+// matches.
+func newCCUsageUnavailableError() error {
+	return lib.WrapError(errCCUsageUnavailable, lib.ErrCodeCCUsage, "ccusage is not available")
+}
+
 // UpdateUsage forces a fresh query to ccusage, bypassing cache
 // Used for immediate updates when user requests refresh
 // Returns error if ccusage command fails or data is invalid
@@ -272,7 +280,7 @@ func (us *UsageService) performUpdateLocked(maxRetries int) (*models.UsageState,
 		}
 
 		if !us.IsAvailable() {
-			lastErr = errCCUsageUnavailable
+			lastErr = newCCUsageUnavailableError()
 			us.logger.Warn("ccusage not available", map[string]interface{}{
 				"attempt": attempt,
 				"path":    us.ccusagePath,
@@ -283,9 +291,6 @@ func (us *UsageService) performUpdateLocked(maxRetries int) (*models.UsageState,
 				continue
 			}
 
-			if lastErr == nil {
-				lastErr = errCCUsageUnavailable
-			}
 			us.recordFailureLocked(lastErr)
 			return us.getStateCopyLocked(), lastErr
 		}
@@ -369,7 +374,7 @@ func (us *UsageService) performUpdateLocked(maxRetries int) (*models.UsageState,
 	}
 
 	if lastErr == nil {
-		lastErr = errCCUsageUnavailable
+		lastErr = newCCUsageUnavailableError()
 	}
 	us.recordFailureLocked(lastErr)
 	return us.getStateCopyLocked(), lastErr

--- a/src/services/usage_service.go
+++ b/src/services/usage_service.go
@@ -21,6 +21,7 @@ var errCCUsageUnavailable = errors.New("ccusage is not available")
 type UsageService struct {
 	lastQuery       time.Time
 	state           *models.UsageState
+	lastErr         error // wrapped error for cached failure state; nil after a successful refresh
 	logger          *lib.Logger
 	ticker          *time.Ticker
 	pollStopChan    chan struct{}
@@ -67,20 +68,21 @@ type CCUsageResponse struct {
 }
 
 // GetDailyUsage queries ccusage and returns current daily statistics. Returns
-// cached data if the last query was within the cache window — including
-// cached *failure* states, so a sustained ccusage outage doesn't trigger one
-// invocation per call (the throttle this PR exists to provide). Cached
-// failures are returned with the original error so callers can distinguish
-// "throttled-from-failure" from "fresh success".
+// cached data if the last query was within the cache window, including cached
+// failure states so a sustained ccusage outage doesn't spawn one invocation
+// per call. Cached failures are returned with the original wrapped error
+// (parse error / command exit / missing binary / zero values) so callers and
+// logs keep the real root cause for the duration of the throttle window.
 func (us *UsageService) GetDailyUsage() (*models.UsageState, error) {
 	us.mutex.RLock()
 	if time.Since(us.lastQuery) < us.cacheWindow {
-		// Copy the cached state while still holding the read lock to avoid
-		// check-then-act races with concurrent writers.
+		// Copy the cached state and error while still holding the read lock
+		// to avoid check-then-act races with concurrent writers.
 		stateCopy := *us.state
+		cachedErr := us.lastErr
 		us.mutex.RUnlock()
 		if !stateCopy.IsAvailable {
-			return &stateCopy, lib.WrapError(errCCUsageUnavailable, lib.ErrCodeCCUsage, "serving cached ccusage failure state")
+			return &stateCopy, cachedFailureError(cachedErr)
 		}
 		return &stateCopy, nil
 	}
@@ -92,12 +94,22 @@ func (us *UsageService) GetDailyUsage() (*models.UsageState, error) {
 	if time.Since(us.lastQuery) < us.cacheWindow {
 		state := us.getStateCopyLocked()
 		if !state.IsAvailable {
-			return state, lib.WrapError(errCCUsageUnavailable, lib.ErrCodeCCUsage, "serving cached ccusage failure state")
+			return state, cachedFailureError(us.lastErr)
 		}
 		return state, nil
 	}
 
 	return us.performUpdateLocked(1)
+}
+
+// cachedFailureError returns the stored wrapped failure error, falling back
+// to a generic unavailable error only when the cache predates a recorded
+// cause (e.g. a manually-seeded failure state).
+func cachedFailureError(cached error) error {
+	if cached != nil {
+		return cached
+	}
+	return lib.WrapError(errCCUsageUnavailable, lib.ErrCodeCCUsage, "serving cached ccusage failure state")
 }
 
 // UpdateUsage forces a fresh query to ccusage, bypassing cache
@@ -126,6 +138,14 @@ func (us *UsageService) setUnknownStateLocked() {
 	us.state.Status = models.Unknown
 }
 
+// recordFailureLocked transitions the cached state to Unknown and stores the
+// wrapped cause so subsequent cached reads can surface the real error
+// instead of a synthesized "unavailable" message.
+func (us *UsageService) recordFailureLocked(err error) {
+	us.setUnknownStateLocked()
+	us.lastErr = err
+}
+
 // setNoDataForToday sets state for when ccusage works but has no data for today
 func (us *UsageService) setNoDataForToday() {
 	us.mutex.Lock()
@@ -136,6 +156,7 @@ func (us *UsageService) setNoDataForToday() {
 func (us *UsageService) setNoDataForTodayLocked() {
 	us.setStateMetricsLocked(0, 0, true)
 	us.updateStatusLocked() // $0.00 cost should evaluate to Green
+	us.lastErr = nil        // success state — clear any prior cached failure
 }
 
 func (us *UsageService) setStateMetricsLocked(tokens int, cost float64, available bool) {
@@ -265,7 +286,7 @@ func (us *UsageService) performUpdateLocked(maxRetries int) (*models.UsageState,
 			if lastErr == nil {
 				lastErr = errCCUsageUnavailable
 			}
-			us.setUnknownStateLocked()
+			us.recordFailureLocked(lastErr)
 			return us.getStateCopyLocked(), lastErr
 		}
 
@@ -294,7 +315,7 @@ func (us *UsageService) performUpdateLocked(maxRetries int) (*models.UsageState,
 			if lastErr == nil {
 				lastErr = err
 			}
-			us.setUnknownStateLocked()
+			us.recordFailureLocked(lastErr)
 			return us.getStateCopyLocked(), lastErr
 		}
 
@@ -305,8 +326,9 @@ func (us *UsageService) performUpdateLocked(maxRetries int) (*models.UsageState,
 				"out_len": len(output),
 				"output":  truncateOutput(output),
 			})
-			us.setUnknownStateLocked()
-			return us.getStateCopyLocked(), lib.WrapError(err, lib.ErrCodeCCUsage, "failed to parse ccusage JSON output")
+			wrapped := lib.WrapError(err, lib.ErrCodeCCUsage, "failed to parse ccusage JSON output")
+			us.recordFailureLocked(wrapped)
+			return us.getStateCopyLocked(), wrapped
 		}
 
 		today := time.Now().Format("2006-01-02")
@@ -326,8 +348,9 @@ func (us *UsageService) performUpdateLocked(maxRetries int) (*models.UsageState,
 				"totalCost":   ccusageOutput.TotalCost,
 				"date":        ccusageOutput.Date,
 			})
-			us.setUnknownStateLocked()
-			return us.getStateCopyLocked(), lib.WrapError(errors.New("ccusage returned zero values"), lib.ErrCodeCCUsage, "ccusage returned invalid zero values")
+			wrapped := lib.WrapError(errors.New("ccusage returned zero values"), lib.ErrCodeCCUsage, "ccusage returned invalid zero values")
+			us.recordFailureLocked(wrapped)
+			return us.getStateCopyLocked(), wrapped
 		}
 
 		us.applyUsageDataLocked(ccusageOutput)
@@ -348,7 +371,7 @@ func (us *UsageService) performUpdateLocked(maxRetries int) (*models.UsageState,
 	if lastErr == nil {
 		lastErr = errCCUsageUnavailable
 	}
-	us.setUnknownStateLocked()
+	us.recordFailureLocked(lastErr)
 	return us.getStateCopyLocked(), lastErr
 }
 
@@ -412,6 +435,7 @@ func availableDates(daily []CCUsageOutput) []string {
 func (us *UsageService) applyUsageDataLocked(output CCUsageOutput) {
 	us.setStateMetricsLocked(output.TotalTokens, output.TotalCost, true)
 	us.updateStatusLocked()
+	us.lastErr = nil // success — clear any prior cached failure
 }
 
 func (us *UsageService) updateStatusLocked() {

--- a/src/services/usage_service.go
+++ b/src/services/usage_service.go
@@ -71,7 +71,7 @@ type CCUsageResponse struct {
 // Returns error if ccusage is unavailable or returns invalid data
 func (us *UsageService) GetDailyUsage() (*models.UsageState, error) {
 	us.mutex.RLock()
-	if time.Since(us.lastQuery) < us.cacheWindow && us.state.IsAvailable {
+	if time.Since(us.lastQuery) < us.cacheWindow {
 		// Copy the cached state while still holding the read lock to avoid
 		// check-then-act races with concurrent writers.
 		stateCopy := *us.state
@@ -83,7 +83,7 @@ func (us *UsageService) GetDailyUsage() (*models.UsageState, error) {
 	us.mutex.Lock()
 	defer us.mutex.Unlock()
 
-	if time.Since(us.lastQuery) < us.cacheWindow && us.state.IsAvailable {
+	if time.Since(us.lastQuery) < us.cacheWindow {
 		return us.getStateCopyLocked(), nil
 	}
 

--- a/src/services/usage_service_test.go
+++ b/src/services/usage_service_test.go
@@ -362,6 +362,65 @@ exit 1`
 	assert.False(t, state.IsAvailable)
 }
 
+// TestUsageService_CommandFailureSetsUnknownState pins down the contract that
+// when ccusage exits non-zero, the cached state is fully rewritten to the
+// Unknown sentinel (not left with stale tokens/cost) and lastQuery is bumped
+// so subsequent GetDailyUsage calls within the cache window see the failure.
+func TestUsageService_CommandFailureSetsUnknownState(t *testing.T) {
+	service := newTestUsageService()
+
+	// Seed the service with stale "successful" state so we can prove the
+	// failure path zeroes it out rather than preserving it.
+	service.state.DailyCount = 999
+	service.state.DailyCost = 99.0
+	service.state.Status = models.Red
+	service.state.IsAvailable = true
+
+	tempDir := t.TempDir()
+	scriptPath := filepath.Join(tempDir, "failing-ccusage")
+	require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/bash\nexit 1"), 0o755))
+	service.ccusagePath = scriptPath
+
+	before := time.Now()
+	state, err := service.updateWithRetry(1)
+	require.Error(t, err)
+
+	assert.False(t, state.IsAvailable)
+	assert.Equal(t, models.Unknown, state.Status)
+	assert.Equal(t, 0, state.DailyCount)
+	assert.Equal(t, 0.0, state.DailyCost)
+	assert.False(t, service.lastQuery.Before(before),
+		"lastQuery should be bumped after command failure to throttle retries")
+}
+
+// TestUsageService_NoDataForTodayNotOverwritten guards against the regression
+// where the post-failure setUnknownStateLocked could clobber the no-data-for-
+// today path. The two branches are mutually exclusive — a successful command
+// with no entry for today must still leave the state Green/IsAvailable=true.
+func TestUsageService_NoDataForTodayNotOverwritten(t *testing.T) {
+	service := newTestUsageService()
+
+	tempDir := t.TempDir()
+	scriptPath := filepath.Join(tempDir, "no-today-ccusage")
+	yesterday := time.Now().AddDate(0, 0, -1).Format("2006-01-02")
+	resp := CCUsageResponse{Daily: []CCUsageOutput{{Date: yesterday, TotalTokens: 5, TotalCost: 0.5}}}
+	resp.Totals.TotalTokens = 5
+	resp.Totals.TotalCost = 0.5
+	jsonData, err := json.Marshal(resp)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(scriptPath,
+		[]byte("#!/bin/bash\necho '"+string(jsonData)+"'"), 0o755))
+	service.ccusagePath = scriptPath
+
+	state, err := service.updateWithRetry(1)
+	require.Error(t, err) // signals "no data for today"
+
+	assert.True(t, state.IsAvailable)
+	assert.Equal(t, models.Green, state.Status)
+	assert.Equal(t, 0, state.DailyCount)
+	assert.Equal(t, 0.0, state.DailyCost)
+}
+
 func TestUsageService_UpdateWithRetry_InvalidJSON(t *testing.T) {
 	service := newTestUsageService()
 

--- a/src/services/usage_service_test.go
+++ b/src/services/usage_service_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"cc-dailyuse-bar/src/lib"
 	"cc-dailyuse-bar/src/models"
 )
 
@@ -209,6 +211,17 @@ func TestUsageService_UpdateUsage_NotAvailable(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not available")
 	assert.False(t, state.IsAvailable)
+
+	// The unavailability path must surface a structured AppError with
+	// ErrCodeCCUsage so callers can branch on type, not just string content.
+	var appErr *lib.AppError
+	require.ErrorAs(t, err, &appErr, "unavailable error must be a *lib.AppError")
+	assert.Equal(t, lib.ErrCodeCCUsage, appErr.Code)
+
+	// The sentinel must still be reachable through Unwrap so existing
+	// errors.Is(err, errCCUsageUnavailable) matchers keep working.
+	assert.True(t, errors.Is(err, errCCUsageUnavailable),
+		"wrapped error must preserve the sentinel in its chain")
 }
 
 func TestUsageService_GetDailyUsage_Cache(t *testing.T) {

--- a/src/services/usage_service_test.go
+++ b/src/services/usage_service_test.go
@@ -277,6 +277,37 @@ func TestUsageService_GetDailyUsage_FailureStateThrottled(t *testing.T) {
 		"lastQuery must not be touched: a fresh ccusage call would have updated it")
 }
 
+// TestUsageService_GetDailyUsage_FailureCausePreserved verifies that the
+// cached failure path surfaces the real wrapped cause (parse error, command
+// exit, etc.) rather than collapsing every failure into a generic
+// "unavailable" error. Without this, callers and logs lose the root cause
+// for the duration of the throttle window.
+func TestUsageService_GetDailyUsage_FailureCausePreserved(t *testing.T) {
+	service := newTestUsageService()
+
+	tempDir := t.TempDir()
+	scriptPath := filepath.Join(tempDir, "invalid-json-ccusage")
+	require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/bash\necho 'not valid json'"), 0o755))
+	service.ccusagePath = scriptPath
+
+	// Drive a real failure through performUpdateLocked so lastErr is populated
+	// with the wrapped parse error.
+	_, firstErr := service.updateWithRetry(1)
+	require.Error(t, firstErr)
+	require.Contains(t, firstErr.Error(), "failed to parse ccusage JSON output")
+
+	// Now hit the cache and confirm the same wrapped cause comes back, not
+	// the synthesized "serving cached ccusage failure state" message.
+	state, cachedErr := service.GetDailyUsage()
+	require.Error(t, cachedErr)
+	assert.False(t, state.IsAvailable)
+	assert.Equal(t, models.Unknown, state.Status)
+	assert.Contains(t, cachedErr.Error(), "failed to parse ccusage JSON output",
+		"cached error must preserve the original cause")
+	assert.NotContains(t, cachedErr.Error(), "serving cached ccusage failure state",
+		"cached error must not collapse to the generic unavailable message")
+}
+
 func TestUsageService_StartPolling_InvalidInterval(t *testing.T) {
 	service := newTestUsageService()
 

--- a/src/services/usage_service_test.go
+++ b/src/services/usage_service_test.go
@@ -248,6 +248,35 @@ func TestUsageService_GetDailyUsage_CacheExpired(t *testing.T) {
 	}
 }
 
+// TestUsageService_GetDailyUsage_FailureStateThrottled is the regression test
+// for the throttle this PR introduced. When the cached state is a failure
+// (IsAvailable=false) and lastQuery is fresh, GetDailyUsage must serve the
+// cached failure (with an error) instead of re-running ccusage. Otherwise
+// every caller hits ccusage during an outage, defeating the throttle.
+func TestUsageService_GetDailyUsage_FailureStateThrottled(t *testing.T) {
+	service := newTestUsageService()
+
+	// Point ccusage at a path that would make every fresh call fail loudly,
+	// so if the cache is bypassed we'd see lastQuery move forward.
+	service.ccusagePath = "/non/existent/cc-shim"
+
+	// Seed a fresh cached failure state.
+	pinned := time.Now()
+	service.state.IsAvailable = false
+	service.state.Status = models.Unknown
+	service.state.DailyCount = 0
+	service.state.DailyCost = 0
+	service.lastQuery = pinned
+
+	state, err := service.GetDailyUsage()
+
+	require.Error(t, err, "cached failure should surface an error to callers")
+	assert.False(t, state.IsAvailable)
+	assert.Equal(t, models.Unknown, state.Status)
+	assert.Equal(t, pinned.UnixNano(), service.lastQuery.UnixNano(),
+		"lastQuery must not be touched: a fresh ccusage call would have updated it")
+}
+
 func TestUsageService_StartPolling_InvalidInterval(t *testing.T) {
 	service := newTestUsageService()
 


### PR DESCRIPTION
## Summary
- mark the usage state as unknown when the ccusage command fails so cache timestamps update

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cb3b11037883218397316125cad203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cached failure/unknown usage results are now served immediately while within the configured cache window and preserve the original failure cause instead of collapsing it into a generic error.
  * Failures now record their cause and transition to an Unknown state; successful updates and “no data for today” clear prior failure info to avoid stale errors.

* **Tests**
  * Added regression tests for cached-failure serving, preserved failure causes, Unknown-state transitions on failures, and handling of “no data for today.”

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/petems/cc-dailyuse-bar/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->