### PR TITLE
fix: ensure ccusage availability checks resolved path

### DIFF
--- a/src/services/usage_service.go
+++ b/src/services/usage_service.go
@@ -156,8 +156,7 @@ func (us *UsageService) IsAvailable() bool {
 		return false
 	}
 
-	pathToCheck := us.ccusagePath
-	info, err := os.Stat(pathToCheck)
+	info, err := os.Stat(us.ccusagePath)
 	if err != nil {
 		resolvedPath, pathErr := exec.LookPath(us.ccusagePath)
 		if pathErr != nil {
@@ -168,8 +167,6 @@ func (us *UsageService) IsAvailable() bool {
 		if err != nil {
 			return false
 		}
-
-		pathToCheck = resolvedPath
 	}
 
 	if info.IsDir() {

--- a/src/services/usage_service.go
+++ b/src/services/usage_service.go
@@ -156,17 +156,18 @@ func (us *UsageService) IsAvailable() bool {
 		return false
 	}
 
-	info, err := os.Stat(us.ccusagePath)
+	// Resolve via exec.LookPath first so the availability check follows the
+	// same rules as exec.CommandContext (PATH-only for bare names, never the
+	// cwd). Otherwise IsAvailable could return true for a file in the working
+	// directory that exec would later fail to find.
+	resolvedPath, err := exec.LookPath(us.ccusagePath)
 	if err != nil {
-		resolvedPath, pathErr := exec.LookPath(us.ccusagePath)
-		if pathErr != nil {
-			return false
-		}
+		return false
+	}
 
-		info, err = os.Stat(resolvedPath)
-		if err != nil {
-			return false
-		}
+	info, err := os.Stat(resolvedPath)
+	if err != nil {
+		return false
 	}
 
 	if info.IsDir() {

--- a/src/services/usage_service.go
+++ b/src/services/usage_service.go
@@ -156,12 +156,20 @@ func (us *UsageService) IsAvailable() bool {
 		return false
 	}
 
-	info, err := os.Stat(us.ccusagePath)
+	pathToCheck := us.ccusagePath
+	info, err := os.Stat(pathToCheck)
 	if err != nil {
-		if _, pathErr := exec.LookPath(us.ccusagePath); pathErr != nil {
+		resolvedPath, pathErr := exec.LookPath(us.ccusagePath)
+		if pathErr != nil {
 			return false
 		}
-		return true
+
+		info, err = os.Stat(resolvedPath)
+		if err != nil {
+			return false
+		}
+
+		pathToCheck = resolvedPath
 	}
 
 	if info.IsDir() {

--- a/src/services/usage_service_test.go
+++ b/src/services/usage_service_test.go
@@ -56,6 +56,30 @@ func TestUsageService_IsAvailable(t *testing.T) {
 	assert.False(t, service.IsAvailable())
 }
 
+// TestUsageService_IsAvailable_ResolvedViaPath covers the new code path
+// introduced by the IsAvailable fix: when os.Stat on the configured value
+// fails, fall back to exec.LookPath and re-stat the resolved binary so a
+// bare command name (e.g. "ccusage") in $PATH is recognised as available.
+func TestUsageService_IsAvailable_ResolvedViaPath(t *testing.T) {
+	service := newTestUsageService()
+
+	tempDir := t.TempDir()
+	binName := "cc-fake-shim"
+	binPath := filepath.Join(tempDir, binName)
+	require.NoError(t, os.WriteFile(binPath, []byte("#!/bin/bash\nexit 0"), 0o755))
+
+	// Prepend tempDir to PATH so LookPath resolves the bare name.
+	t.Setenv("PATH", tempDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	service.ccusagePath = binName
+	assert.True(t, service.IsAvailable(),
+		"bare command name resolvable via PATH should be reported available")
+
+	// Sanity: a bare name that is *not* in PATH must still be unavailable.
+	service.ccusagePath = "definitely-not-on-path-cc-shim-xyz"
+	assert.False(t, service.IsAvailable())
+}
+
 func TestUsageService_SetCCUsagePath(t *testing.T) {
 	service := newTestUsageService()
 

--- a/src/services/usage_service_test.go
+++ b/src/services/usage_service_test.go
@@ -95,10 +95,7 @@ func TestUsageService_IsAvailable_BareNameInCWDNotOnPath(t *testing.T) {
 
 	// Make tempDir the cwd but exclude it from PATH so the only way to
 	// "find" the binary is via the (incorrect) cwd-stat code path.
-	prevCwd, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(tempDir))
-	t.Cleanup(func() { _ = os.Chdir(prevCwd) })
+	t.Chdir(tempDir)
 	t.Setenv("PATH", "/usr/bin:/bin")
 
 	service.ccusagePath = binName

--- a/src/services/usage_service_test.go
+++ b/src/services/usage_service_test.go
@@ -80,6 +80,32 @@ func TestUsageService_IsAvailable_ResolvedViaPath(t *testing.T) {
 	assert.False(t, service.IsAvailable())
 }
 
+// TestUsageService_IsAvailable_BareNameInCWDNotOnPath guards against the
+// false-positive where IsAvailable used to report a bare command name as
+// available just because a same-named file existed in the cwd. exec.Command
+// resolves bare names via PATH only (never the cwd since Go 1.19), so the
+// availability check must stay aligned with that.
+func TestUsageService_IsAvailable_BareNameInCWDNotOnPath(t *testing.T) {
+	service := newTestUsageService()
+
+	tempDir := t.TempDir()
+	binName := "cc-cwd-only-shim"
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, binName),
+		[]byte("#!/bin/bash\nexit 0"), 0o755))
+
+	// Make tempDir the cwd but exclude it from PATH so the only way to
+	// "find" the binary is via the (incorrect) cwd-stat code path.
+	prevCwd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tempDir))
+	t.Cleanup(func() { _ = os.Chdir(prevCwd) })
+	t.Setenv("PATH", "/usr/bin:/bin")
+
+	service.ccusagePath = binName
+	assert.False(t, service.IsAvailable(),
+		"bare name resolvable only via cwd (not PATH) must report unavailable")
+}
+
 func TestUsageService_SetCCUsagePath(t *testing.T) {
 	service := newTestUsageService()
 

--- a/src/services/usage_service_test.go
+++ b/src/services/usage_service_test.go
@@ -56,10 +56,11 @@ func TestUsageService_IsAvailable(t *testing.T) {
 	assert.False(t, service.IsAvailable())
 }
 
-// TestUsageService_IsAvailable_ResolvedViaPath covers the new code path
-// introduced by the IsAvailable fix: when os.Stat on the configured value
-// fails, fall back to exec.LookPath and re-stat the resolved binary so a
-// bare command name (e.g. "ccusage") in $PATH is recognised as available.
+// TestUsageService_IsAvailable_ResolvedViaPath covers the IsAvailable code
+// path where exec.LookPath resolves a bare command name from $PATH and
+// os.Stat then verifies the resolved binary. This mirrors the resolution
+// exec.CommandContext uses, so a bare name (e.g. "ccusage") in $PATH must
+// be reported available.
 func TestUsageService_IsAvailable_ResolvedViaPath(t *testing.T) {
 	service := newTestUsageService()
 


### PR DESCRIPTION
## Summary
- ensure the usage service re-stats the resolved ccusage binary when os.Stat fails
- prevent IsAvailable from reporting success without confirming the executable bit on the located binary

## Testing
- go test ./src/services -run TestUsageService_IsAvailable -v


------
https://chatgpt.com/codex/tasks/task_e_68cb3b2083e08321aa1000e28f019867

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved executable availability detection so configured paths are validated and the system PATH is used reliably as a fallback.
* **Tests**
  * Added unit tests verifying bare command names are resolved via PATH and that executables only present in the working directory are not reported as available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->