### PR TITLE
build(goreleaser): wire darwin universal release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,7 +3,7 @@ version: 2
 project_name: cc-dailyuse-bar
 
 builds:
-  - id: darwin-amd64
+  - id: darwin
     main: ./src
     binary: cc-dailyuse-bar
     env:
@@ -14,32 +14,19 @@ builds:
       - darwin
     goarch:
       - amd64
-    ldflags:
-      - -s -w
-
-  - id: darwin-arm64
-    main: ./src
-    binary: cc-dailyuse-bar
-    env:
-      - CGO_ENABLED=1
-      - CGO_CFLAGS=-mmacosx-version-min=12.0
-      - CGO_LDFLAGS=-mmacosx-version-min=12.0
-    goos:
-      - darwin
-    goarch:
       - arm64
     ldflags:
       - -s -w
 
-# Linux build intentionally omitted: getlantern/systray requires CGO+GTK on Linux,
-# which needs a Linux runner with libgtk-3-dev installed. Add back when a Linux
-# release pipeline is desired.
+# Linux build intentionally omitted: getlantern/systray on Linux needs CGO and
+# the systray deps the rest of the repo documents (libayatana-appindicator3-dev
+# and pkg-config — see README.md and .github/workflows/golang.yml). Add back
+# when a Linux release pipeline is desired.
 
 universal_binaries:
   - id: darwin-universal
     ids:
-      - darwin-amd64
-      - darwin-arm64
+      - darwin
     name_template: cc-dailyuse-bar
     replace: false
 
@@ -56,8 +43,11 @@ archives:
 # and pushes a hand-templated cask file to petems/homebrew-tap.
 
 release:
+  # Narrow glob so only the current run's universal DMG attaches; avoids picking
+  # up stale artifacts if dist/ was not cleaned. The release workflow also runs
+  # `goreleaser release --clean` which wipes dist/ anyway, but defense in depth.
   extra_files:
-    - glob: ./dist/*.dmg
+    - glob: ./dist/cc-dailyuse-bar_*_universal.dmg
 
 changelog:
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,62 +3,61 @@ version: 2
 project_name: cc-dailyuse-bar
 
 builds:
-  - id: cc-dailyuse-bar-darwin
+  - id: darwin-amd64
     main: ./src
     binary: cc-dailyuse-bar
     env:
       - CGO_ENABLED=1
+      - CGO_CFLAGS=-mmacosx-version-min=12.0
+      - CGO_LDFLAGS=-mmacosx-version-min=12.0
     goos:
       - darwin
     goarch:
       - amd64
-      - arm64
     ldflags:
       - -s -w
-  - id: cc-dailyuse-bar-linux
+
+  - id: darwin-arm64
     main: ./src
     binary: cc-dailyuse-bar
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
+      - CGO_CFLAGS=-mmacosx-version-min=12.0
+      - CGO_LDFLAGS=-mmacosx-version-min=12.0
     goos:
-      - linux
+      - darwin
     goarch:
-      - amd64
       - arm64
     ldflags:
       - -s -w
 
+# Linux build intentionally omitted: getlantern/systray requires CGO+GTK on Linux,
+# which needs a Linux runner with libgtk-3-dev installed. Add back when a Linux
+# release pipeline is desired.
+
+universal_binaries:
+  - id: darwin-universal
+    ids:
+      - darwin-amd64
+      - darwin-arm64
+    name_template: cc-dailyuse-bar
+    replace: false
+
 archives:
   - id: default
-    format: tar.gz
+    formats:
+      - tar.gz
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
 
-# macOS code signing (requires Developer ID certificate)
-# Uncomment when certificate is available:
-#
-# signs:
-#   - id: darwin
-#     cmd: codesign
-#     args:
-#       - "--deep"
-#       - "--force"
-#       - "--options=runtime"
-#       - "--entitlements=packaging/macos/entitlements.plist"
-#       - "--sign"
-#       - "Developer ID Application: YOUR_NAME (TEAM_ID)"
-#       - "{{ .Path }}"
-#     artifacts: binary
+# Homebrew cask publishing is handled by a separate workflow step.
+# OSS GoReleaser's `homebrew_casks` block generates a `binary` stanza, not the
+# `app "CC Daily Use Bar.app"` stanza we need for a DMG-delivered .app bundle
+# (the `app:` field is Pro-only). The release workflow computes the DMG sha256
+# and pushes a hand-templated cask file to petems/homebrew-tap.
 
-# macOS notarization (requires Apple Developer credentials)
-# Uncomment when ready:
-#
-# notarize:
-#   - macos:
-#       - enabled: true
-#         ids:
-#           - cc-dailyuse-bar
-#         notarytool:
-#           keychain_profile: CC_DAILYUSE_BAR
+release:
+  extra_files:
+    - glob: ./dist/*.dmg
 
 changelog:
   sort: asc


### PR DESCRIPTION
## Summary

First slice of the macOS deliverable pipeline (universal `.app` + signed/notarized DMG + Homebrew cask). This PR lands the GoReleaser config rework that all the downstream phases build on; the `.app`/sign/DMG/notarize driver and the GitHub Actions release workflow follow in subsequent PRs.

### What changed in `.goreleaser.yaml`

* Split the single `cc-dailyuse-bar-darwin` build into per-arch `darwin-amd64` / `darwin-arm64` builds. Both set `CGO_CFLAGS`/`CGO_LDFLAGS=-mmacosx-version-min=12.0` so cross-compilation on the `macos-latest` arm64 runner produces binaries that run on macOS 12+.
* Added a `universal_binaries:` block that `lipo`s the two arches into a fat binary. `replace: false` keeps the per-arch tar.gz archives shipping alongside the universal one.
* Removed the commented-out `signs:` / `notarize:` skeleton from #15. `notarize:` is Pro-only in OSS GoReleaser, so notarization will live in a forthcoming `scripts/macos-package.sh` driver instead. No functionality lost — the comments were aspirational.
* Removed the Linux build. `getlantern/systray` needs CGO+GTK on Linux but the config had `CGO_ENABLED=0`; it was already broken on master. A comment explains how to re-add when a Linux release path is wanted. The `make build-linux` Makefile target is unaffected.
* Added `release.extra_files: glob: ./dist/*.dmg` so the DMG produced by the upcoming packaging script attaches to the GitHub release.
* `archives.format` → `formats:` (singular was deprecated in v2).

### Why no `homebrew_casks:` block

The `app:` field inside `homebrew_casks:` is GoReleaser Pro-only and is hard-rejected at config validation. OSS would emit a `binary` cask stanza, which doesn't fit a DMG-delivered `.app`. Cask publishing will be handled by a separate workflow step that computes the DMG sha256 and pushes a hand-templated cask file to `petems/homebrew-tap`.

### Verification

```bash
goreleaser check                                      # ✅ passes
goreleaser release --snapshot --clean --skip=publish  # ✅ produces all archives
lipo -info dist/darwin-universal_darwin_all/cc-dailyuse-bar
# → arm64 x86_64
```

Artifacts produced (snapshot mode):

| File | Size | Contents |
|---|---|---|
| `cc-dailyuse-bar_darwin_amd64.tar.gz` | 1.9M | Intel-only binary |
| `cc-dailyuse-bar_darwin_arm64.tar.gz` | 1.8M | Apple Silicon binary |
| `cc-dailyuse-bar_darwin_all.tar.gz` | 3.8M | Universal binary |

## Test plan

- [ ] CI green on this PR (existing `golang.yml` workflow still runs build/test).
- [ ] Reviewer runs `goreleaser check` locally and gets a clean validation.
- [ ] Reviewer runs `goreleaser release --snapshot --clean --skip=publish` and confirms all three archives appear in `dist/`.
- [ ] Reviewer confirms `lipo -info` on the universal binary reports both `arm64` and `x86_64`.

Refs #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized macOS builds to produce a single multi‑architecture (universal) app
  * Stopped producing Linux build artifacts in release output
  * Release archives standardized to tar.gz format
  * DMG files for the universal macOS builds are now included as release artifacts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->