### PR TITLE
feat(release): sign and notarize macOS releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-24.04, macos-15]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -30,7 +30,7 @@ jobs:
           go-version: '1.25.x'
 
       - name: Install system dependencies (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-24.04'
         run: |
           sudo apt update
           sudo apt install -y libayatana-appindicator3-dev pkg-config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.25.x'
 
@@ -45,7 +45,7 @@ jobs:
         run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-${{ matrix.os }}
           path: coverage.out

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze (Go)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       security-events: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,10 +22,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.25.x'
 
@@ -35,14 +35,14 @@ jobs:
           sudo apt install -y libayatana-appindicator3-dev pkg-config
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           languages: go
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           category: "/language:go"

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -24,7 +24,7 @@ jobs:
       # collides with v6's credential persistence model and causes a duplicate
       # Authorization header on the nested fetch. Disable credential persistence
       # here so the nested checkout can attach its own auth cleanly.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
@@ -34,7 +34,7 @@ jobs:
           sudo apt install -y libayatana-appindicator3-dev pkg-config
 
       - name: Run govulncheck
-        uses: golang/govulncheck-action@v1
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1
         with:
           go-version-input: '1.25.x'
           check-latest: true

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   govulncheck:
     name: govulncheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # govulncheck-action@v1 internally runs actions/checkout@v4.1.1, which
       # collides with v6's credential persistence model and causes a duplicate

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   golangci-lint:
     name: golangci-lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,10 +18,10 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.25.x'
 
@@ -31,6 +31,6 @@ jobs:
           sudo apt install -y libayatana-appindicator3-dev pkg-config
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
           version: v2.11.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,15 @@ jobs:
           spctl --assess --type open --context context:primary-signature -vv "$DMG"
           xcrun stapler validate "$DMG"
 
+      # Drop the .p8 + signing keychain as soon as verification passes so later
+      # steps (goreleaser publish, artifact upload, future cask push) can't
+      # inherit secrets they don't need. The trailing `if: always()` cleanup
+      # below covers failure paths where this step never runs.
+      - name: Cleanup signing material (early)
+        run: |
+          rm -f "$AC_API_KEY_PATH"
+          security delete-keychain signing_temp.keychain
+
       # Second goreleaser pass: archive + GitHub release. release.extra_files in
       # .goreleaser.yaml picks up the signed+notarized DMG. Only run on real tags.
       - name: GoReleaser — release
@@ -172,6 +181,11 @@ jobs:
       # signed DMG flow is verified end-to-end. See comment block at
       # .goreleaser.yaml:39-43 for context. Requires HOMEBREW_TAP_TOKEN secret.
 
-      - name: Cleanup signing keychain
+      # Fallback cleanup for failure paths where the early cleanup never ran.
+      # `|| true` is intentional here so this step doesn't mask the real
+      # failure when the keychain / .p8 are already gone.
+      - name: Cleanup signing material (fallback)
         if: always()
-        run: security delete-keychain signing_temp.keychain || true
+        run: |
+          rm -f "$AC_API_KEY_PATH" || true
+          security delete-keychain signing_temp.keychain || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           echo "Releasing version: $VERSION (tag=$IS_TAG)"
 
       - name: Import Developer ID Application certificate
-        uses: apple-actions/import-codesign-certs@v3
+        uses: apple-actions/import-codesign-certs@v7
         with:
           p12-file-base64: ${{ secrets.MACOS_CERTIFICATE }}
           p12-password: ${{ secrets.MACOS_CERTIFICATE_PWD }}
@@ -69,14 +69,14 @@ jobs:
       # before any artifacts are released.
       - name: GoReleaser — build only (tag)
         if: env.IS_TAG == 'true'
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
           args: release --clean --skip=archive,publish
 
       - name: GoReleaser — build only (dispatch / snapshot)
         if: env.IS_TAG != 'true'
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
           args: release --clean --skip=archive,publish --snapshot
@@ -138,7 +138,7 @@ jobs:
       # .goreleaser.yaml picks up the signed+notarized DMG. Only run on real tags.
       - name: GoReleaser — release
         if: env.IS_TAG == 'true'
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
           args: release --clean=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,166 @@
+name: release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Build, sign, notarize, release
+    runs-on: macos-latest
+    timeout-minutes: 45
+    env:
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      AC_API_KEY_ID: ${{ secrets.AC_API_KEY_ID }}
+      AC_API_ISSUER_ID: ${{ secrets.AC_API_ISSUER_ID }}
+      MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # goreleaser needs full history for changelog
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install create-dmg
+        run: brew install create-dmg
+
+      - name: Compute version
+        id: version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+            IS_TAG=true
+          else
+            VERSION="0.0.0-${GITHUB_SHA:0:7}"
+            IS_TAG=false
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "IS_TAG=$IS_TAG" >> "$GITHUB_ENV"
+          echo "Releasing version: $VERSION (tag=$IS_TAG)"
+
+      - name: Import Developer ID Application certificate
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.MACOS_CERTIFICATE }}
+          p12-password: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+
+      - name: Write App Store Connect API key
+        env:
+          AC_API_KEY_B64: ${{ secrets.AC_API_KEY }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/keys"
+          echo "$AC_API_KEY_B64" | base64 --decode > "$RUNNER_TEMP/keys/AuthKey.p8"
+          chmod 600 "$RUNNER_TEMP/keys/AuthKey.p8"
+          echo "AC_API_KEY_PATH=$RUNNER_TEMP/keys/AuthKey.p8" >> "$GITHUB_ENV"
+
+      # First goreleaser pass: build per-arch binaries + lipo into a universal
+      # Mach-O. Skip archive/publish so we can sign + notarize the .app bundle
+      # before any artifacts are released.
+      - name: GoReleaser — build only (tag)
+        if: env.IS_TAG == 'true'
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean --skip=archive,publish
+
+      - name: GoReleaser — build only (dispatch / snapshot)
+        if: env.IS_TAG != 'true'
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean --skip=archive,publish --snapshot
+
+      - name: Bundle .app from universal binary
+        run: |
+          UNIVERSAL_BIN=$(find dist -type f -name cc-dailyuse-bar -path '*universal*' | head -1)
+          if [[ -z "$UNIVERSAL_BIN" ]]; then
+            echo "Could not locate universal binary under dist/" >&2
+            find dist -type f -name cc-dailyuse-bar >&2
+            exit 1
+          fi
+          echo "Bundling from $UNIVERSAL_BIN"
+          make bundle-macos BINARY_PATH="$UNIVERSAL_BIN" VERSION="$VERSION"
+
+      - name: Codesign .app
+        run: |
+          codesign --force --deep --options=runtime --timestamp \
+            --entitlements packaging/macos/entitlements.plist \
+            --sign "$MACOS_CERTIFICATE_NAME" \
+            "CC Daily Use Bar.app"
+          codesign --verify --deep --strict --verbose=2 "CC Daily Use Bar.app"
+
+      - name: Notarize + staple .app
+        run: |
+          ditto -c -k --keepParent "CC Daily Use Bar.app" "CC Daily Use Bar.zip"
+          xcrun notarytool submit "CC Daily Use Bar.zip" \
+            --key "$AC_API_KEY_PATH" \
+            --key-id "$AC_API_KEY_ID" \
+            --issuer "$AC_API_ISSUER_ID" \
+            --wait
+          xcrun stapler staple "CC Daily Use Bar.app"
+          rm "CC Daily Use Bar.zip"
+
+      - name: Build DMG
+        run: make dmg-macos VERSION="$VERSION"
+
+      - name: Codesign + notarize + staple DMG
+        run: |
+          DMG=$(ls dist/cc-dailyuse-bar_*_universal.dmg)
+          codesign --force --timestamp --sign "$MACOS_CERTIFICATE_NAME" "$DMG"
+          xcrun notarytool submit "$DMG" \
+            --key "$AC_API_KEY_PATH" \
+            --key-id "$AC_API_KEY_ID" \
+            --issuer "$AC_API_ISSUER_ID" \
+            --wait
+          xcrun stapler staple "$DMG"
+
+      - name: Verify signing + notarization
+        run: |
+          codesign --verify --deep --strict --verbose=2 "CC Daily Use Bar.app"
+          spctl --assess --type exec --verbose=2 "CC Daily Use Bar.app"
+          xcrun stapler validate "CC Daily Use Bar.app"
+          DMG=$(ls dist/cc-dailyuse-bar_*_universal.dmg)
+          spctl --assess --type open --context context:primary-signature -vv "$DMG"
+          xcrun stapler validate "$DMG"
+
+      # Second goreleaser pass: archive + GitHub release. release.extra_files in
+      # .goreleaser.yaml picks up the signed+notarized DMG. Only run on real tags.
+      - name: GoReleaser — release
+        if: env.IS_TAG == 'true'
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean=false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Surface the artifacts on workflow_dispatch dry-runs so they can be
+      # manually inspected without a tag/release.
+      - name: Upload dry-run artifacts
+        if: env.IS_TAG != 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-release-dryrun
+          path: |
+            CC Daily Use Bar.app
+            dist/cc-dailyuse-bar_*_universal.dmg
+          if-no-files-found: error
+
+      # TODO: push a hand-templated cask file to petems/homebrew-tap once the
+      # signed DMG flow is verified end-to-end. See comment block at
+      # .goreleaser.yaml:39-43 for context. Requires HOMEBREW_TAP_TOKEN secret.
+
+      - name: Cleanup signing keychain
+        if: always()
+        run: security delete-keychain signing_temp.keychain || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
       AC_API_KEY_ID: ${{ secrets.AC_API_KEY_ID }}
       AC_API_ISSUER_ID: ${{ secrets.AC_API_ISSUER_ID }}
       MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
+      # Pin GoReleaser binary so releases are reproducible. Bump deliberately.
+      GORELEASER_VERSION: v2.15.4
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -39,10 +41,16 @@ jobs:
         id: version
         run: |
           # Apple's CFBundleShortVersionString accepts only digits and periods,
-          # so non-tag dispatch builds use a plain "0.0.0" placeholder. Real
-          # provenance for dry-runs lives in CI logs / GITHUB_SHA, not the plist.
+          # so we hard-fail on non-strict X.Y.Z tags (e.g. v1.2.3-rc1) rather
+          # than letting an invalid string into the plist. Non-tag dispatch
+          # builds use a plain "0.0.0" placeholder; real provenance for
+          # dry-runs lives in CI logs / GITHUB_SHA, not the plist.
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF_NAME#v}"
+            if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Tag $GITHUB_REF_NAME does not match strict X.Y.Z format required for CFBundleShortVersionString" >&2
+              exit 1
+            fi
             IS_TAG=true
           else
             VERSION="0.0.0"
@@ -74,14 +82,14 @@ jobs:
         if: env.IS_TAG == 'true'
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
         with:
-          version: latest
+          version: ${{ env.GORELEASER_VERSION }}
           args: release --clean --skip=archive,publish
 
       - name: GoReleaser — build only (dispatch / snapshot)
         if: env.IS_TAG != 'true'
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
         with:
-          version: latest
+          version: ${{ env.GORELEASER_VERSION }}
           args: release --clean --skip=archive,publish --snapshot
 
       - name: Bundle .app from universal binary
@@ -143,7 +151,7 @@ jobs:
         if: env.IS_TAG == 'true'
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
         with:
-          version: latest
+          version: ${{ env.GORELEASER_VERSION }}
           args: release --clean=false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,11 @@ jobs:
       AC_API_ISSUER_ID: ${{ secrets.AC_API_ISSUER_ID }}
       MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0  # goreleaser needs full history for changelog
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -38,11 +38,14 @@ jobs:
       - name: Compute version
         id: version
         run: |
+          # Apple's CFBundleShortVersionString accepts only digits and periods,
+          # so non-tag dispatch builds use a plain "0.0.0" placeholder. Real
+          # provenance for dry-runs lives in CI logs / GITHUB_SHA, not the plist.
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF_NAME#v}"
             IS_TAG=true
           else
-            VERSION="0.0.0-${GITHUB_SHA:0:7}"
+            VERSION="0.0.0"
             IS_TAG=false
           fi
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
@@ -50,7 +53,7 @@ jobs:
           echo "Releasing version: $VERSION (tag=$IS_TAG)"
 
       - name: Import Developer ID Application certificate
-        uses: apple-actions/import-codesign-certs@v7
+        uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7
         with:
           p12-file-base64: ${{ secrets.MACOS_CERTIFICATE }}
           p12-password: ${{ secrets.MACOS_CERTIFICATE_PWD }}
@@ -69,14 +72,14 @@ jobs:
       # before any artifacts are released.
       - name: GoReleaser — build only (tag)
         if: env.IS_TAG == 'true'
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
         with:
           version: latest
           args: release --clean --skip=archive,publish
 
       - name: GoReleaser — build only (dispatch / snapshot)
         if: env.IS_TAG != 'true'
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
         with:
           version: latest
           args: release --clean --skip=archive,publish --snapshot
@@ -138,7 +141,7 @@ jobs:
       # .goreleaser.yaml picks up the signed+notarized DMG. Only run on real tags.
       - name: GoReleaser — release
         if: env.IS_TAG == 'true'
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
         with:
           version: latest
           args: release --clean=false
@@ -149,7 +152,7 @@ jobs:
       # manually inspected without a tag/release.
       - name: Upload dry-run artifacts
         if: env.IS_TAG != 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: macos-release-dryrun
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   release:
     name: Build, sign, notarize, release
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 45
     env:
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}

--- a/Makefile
+++ b/Makefile
@@ -186,13 +186,11 @@ bundle-macos: build
 	mkdir -p "$(APP_BUNDLE)/Contents/MacOS"
 	mkdir -p "$(APP_BUNDLE)/Contents/Resources"
 	cp "$(BINARY_PATH)" "$(APP_BUNDLE)/Contents/MacOS/$(BINARY_NAME)"
-	cp packaging/macos/Info.plist "$(APP_BUNDLE)/Contents/"
-	sed -i '' \
-	  -e 's/__CFBUNDLE_VERSION__/$(BUNDLE_VERSION)/g' \
-	  -e 's/__CFBUNDLE_SHORT_VERSION__/$(BUNDLE_VERSION)/g' \
-	  "$(APP_BUNDLE)/Contents/Info.plist"
+	sed -e 's/__CFBUNDLE_VERSION__/$(BUNDLE_VERSION)/g' \
+	    -e 's/__CFBUNDLE_SHORT_VERSION__/$(BUNDLE_VERSION)/g' \
+	    packaging/macos/Info.plist > "$(APP_BUNDLE)/Contents/Info.plist"
 	@echo "Bundle created: $(APP_BUNDLE) (version=$(BUNDLE_VERSION))"
-	@echo "To sign: codesign --deep --force --options=runtime --entitlements=packaging/macos/entitlements.plist --sign 'Developer ID Application: YOUR_NAME' '$(APP_BUNDLE)'"
+	@echo "To sign: codesign --deep --force --options=runtime --timestamp --entitlements=packaging/macos/entitlements.plist --sign 'Developer ID Application: YOUR_NAME' '$(APP_BUNDLE)'"
 
 # Build a signed-and-stapled-ready DMG from the .app bundle. Output filename
 # matches the .goreleaser.yaml release.extra_files glob.
@@ -200,7 +198,7 @@ dmg-macos:
 	@command -v create-dmg >/dev/null 2>&1 || { echo "Error: create-dmg not found. Install with: brew install create-dmg"; exit 1; }
 	@test -d "$(APP_BUNDLE)" || { echo "Error: $(APP_BUNDLE) not found. Run 'make bundle-macos' first."; exit 1; }
 	mkdir -p dist
-	rm -f "dist/cc-dailyuse-bar_$(BUNDLE_VERSION)_universal.dmg"
+	rm -f "dist/$(BINARY_NAME)_$(BUNDLE_VERSION)_universal.dmg"
 	create-dmg \
 	  --volname "CC Daily Use Bar" \
 	  --window-size 540 380 \
@@ -208,9 +206,9 @@ dmg-macos:
 	  --icon "$(APP_BUNDLE)" 140 190 \
 	  --app-drop-link 400 190 \
 	  --hdiutil-quiet \
-	  "dist/cc-dailyuse-bar_$(BUNDLE_VERSION)_universal.dmg" \
+	  "dist/$(BINARY_NAME)_$(BUNDLE_VERSION)_universal.dmg" \
 	  "$(APP_BUNDLE)"
-	@echo "DMG created: dist/cc-dailyuse-bar_$(BUNDLE_VERSION)_universal.dmg"
+	@echo "DMG created: dist/$(BINARY_NAME)_$(BUNDLE_VERSION)_universal.dmg"
 
 # Run formatters
 format:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ LDFLAGS_GUI=-ldflags "$(LDFLAGS_FLAGS) -H windowsgui"
 BUILD_FLAGS=-v
 
 .PHONY: all build clean test coverage coverage-html coverage-func deps lint fmt vet help run install \
-	install-service-macos uninstall-service-macos bundle-macos
+	install-service-macos uninstall-service-macos bundle-macos dmg-macos
 
 # Default target
 all: clean deps lint test build
@@ -166,19 +166,51 @@ uninstall-service-macos:
 # macOS .app bundle variables
 APP_NAME=CC Daily Use Bar
 APP_BUNDLE=$(APP_NAME).app
+# Source binary for bundle-macos. Defaults to the locally-built BINARY_NAME so
+# `make build bundle-macos` still works; override in CI to point at the
+# goreleaser-built universal binary, e.g.
+#   make bundle-macos BINARY_PATH=dist/darwin-universal_darwin_all/cc-dailyuse-bar
+BINARY_PATH?=$(BINARY_NAME)
+# Strip a leading `v` so plist version strings ("0.1.0") don't include the tag prefix.
+BUNDLE_VERSION=$(VERSION:v%=%)
 
-# Build macOS .app bundle
+# Build macOS .app bundle. Depends on `build` so `make bundle-macos` works
+# standalone for local devs; CI overrides BINARY_PATH to point at the
+# goreleaser-built universal binary, in which case the `: build` rebuild is
+# redundant but harmless.
 bundle-macos: build
-	@echo "Verifying binary is a macOS Mach-O executable..."
-	@file $(BINARY_NAME) | grep -q Mach-O || { echo "Error: $(BINARY_NAME) is not a macOS binary. Run on macOS or cross-compile for darwin."; exit 1; }
+	@echo "Verifying binary at $(BINARY_PATH) is a macOS Mach-O executable..."
+	@file "$(BINARY_PATH)" | grep -q Mach-O || { echo "Error: $(BINARY_PATH) is not a macOS binary. Run 'make build' first or set BINARY_PATH to a darwin Mach-O."; exit 1; }
 	@echo "Creating macOS .app bundle..."
 	rm -rf "$(APP_BUNDLE)"
 	mkdir -p "$(APP_BUNDLE)/Contents/MacOS"
 	mkdir -p "$(APP_BUNDLE)/Contents/Resources"
-	cp $(BINARY_NAME) "$(APP_BUNDLE)/Contents/MacOS/"
+	cp "$(BINARY_PATH)" "$(APP_BUNDLE)/Contents/MacOS/$(BINARY_NAME)"
 	cp packaging/macos/Info.plist "$(APP_BUNDLE)/Contents/"
-	@echo "Bundle created: $(APP_BUNDLE)"
+	sed -i '' \
+	  -e 's/__CFBUNDLE_VERSION__/$(BUNDLE_VERSION)/g' \
+	  -e 's/__CFBUNDLE_SHORT_VERSION__/$(BUNDLE_VERSION)/g' \
+	  "$(APP_BUNDLE)/Contents/Info.plist"
+	@echo "Bundle created: $(APP_BUNDLE) (version=$(BUNDLE_VERSION))"
 	@echo "To sign: codesign --deep --force --options=runtime --entitlements=packaging/macos/entitlements.plist --sign 'Developer ID Application: YOUR_NAME' '$(APP_BUNDLE)'"
+
+# Build a signed-and-stapled-ready DMG from the .app bundle. Output filename
+# matches the .goreleaser.yaml release.extra_files glob.
+dmg-macos:
+	@command -v create-dmg >/dev/null 2>&1 || { echo "Error: create-dmg not found. Install with: brew install create-dmg"; exit 1; }
+	@test -d "$(APP_BUNDLE)" || { echo "Error: $(APP_BUNDLE) not found. Run 'make bundle-macos' first."; exit 1; }
+	mkdir -p dist
+	rm -f "dist/cc-dailyuse-bar_$(BUNDLE_VERSION)_universal.dmg"
+	create-dmg \
+	  --volname "CC Daily Use Bar" \
+	  --window-size 540 380 \
+	  --icon-size 96 \
+	  --icon "$(APP_BUNDLE)" 140 190 \
+	  --app-drop-link 400 190 \
+	  --hdiutil-quiet \
+	  "dist/cc-dailyuse-bar_$(BUNDLE_VERSION)_universal.dmg" \
+	  "$(APP_BUNDLE)"
+	@echo "DMG created: dist/cc-dailyuse-bar_$(BUNDLE_VERSION)_universal.dmg"
 
 # Run formatters
 format:
@@ -248,7 +280,8 @@ help:
 	@echo "  uninstall-service - Remove systemd service (Linux)"
 	@echo "  install-service-macos - Install as macOS LaunchAgent"
 	@echo "  uninstall-service-macos - Remove macOS LaunchAgent"
-	@echo "  bundle-macos   - Build macOS .app bundle"
+	@echo "  bundle-macos   - Build macOS .app bundle (override BINARY_PATH for prebuilt binaries)"
+	@echo "  dmg-macos      - Build DMG from .app bundle (requires: brew install create-dmg)"
 	@echo "  format       - Format code (fmt + lint-fix)"
 	@echo "  security     - Check for security vulnerabilities"
 	@echo "  mocks        - Generate mocks"

--- a/packaging/macos/Info.plist
+++ b/packaging/macos/Info.plist
@@ -12,10 +12,10 @@
     <string>com.cc-dailyuse-bar</string>
 
     <key>CFBundleVersion</key>
-    <string>0.1.0</string>
+    <string>__CFBUNDLE_VERSION__</string>
 
     <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
+    <string>__CFBUNDLE_SHORT_VERSION__</string>
 
     <key>CFBundlePackageType</key>
     <string>APPL</string>

--- a/packaging/macos/SIGNING.md
+++ b/packaging/macos/SIGNING.md
@@ -1,95 +1,126 @@
 # macOS Code Signing & Notarization
 
-This document describes how to sign and notarize cc-dailyuse-bar for macOS distribution.
+For tagged releases this happens automatically in `.github/workflows/release.yml`
+on `macos-latest`. This document is the local/manual reference for ad-hoc
+debugging — if you're cutting a release, just push a tag.
 
 ## Prerequisites
 
-- An Apple Developer account ($99/year) with a **Developer ID Application** certificate
-- Xcode command line tools installed (`xcode-select --install`)
-- The certificate installed in your Keychain
+- An Apple Developer membership ($99/year) with a **Developer ID Application** certificate
+- Xcode command line tools (`xcode-select --install`)
+- The certificate installed in your login Keychain
+- An [App Store Connect API key](https://appstoreconnect.apple.com/access/integrations/api)
+  (the .p8 file, plus its Key ID and Issuer ID) for notarization
 
-## Build the .app Bundle
+## Build the .app bundle
 
 ```bash
+make build
 make bundle-macos
 ```
 
-This creates `CC Daily Use Bar.app/` with the correct directory structure.
+The `bundle-macos` target stamps `CFBundleVersion` / `CFBundleShortVersionString`
+from `$(VERSION)` (defaults to `git describe`). Override `BINARY_PATH` if you want
+to bundle a pre-built binary (for example, the universal Mach-O produced by
+`goreleaser build`):
+
+```bash
+make bundle-macos BINARY_PATH=dist/darwin-universal_darwin_all/cc-dailyuse-bar
+```
 
 ## Code Signing
 
-Sign the bundle with hardened runtime (required for notarization):
+Sign the bundle with hardened runtime + secure timestamp (both required for notarization):
 
 ```bash
-codesign --deep --force \
-  --options=runtime \
-  --entitlements=packaging/macos/entitlements.plist \
+codesign --force --deep --options=runtime --timestamp \
+  --entitlements packaging/macos/entitlements.plist \
   --sign "Developer ID Application: YOUR_NAME (TEAM_ID)" \
   "CC Daily Use Bar.app"
 ```
 
 ### Entitlements
 
-The `entitlements.plist` includes:
+`packaging/macos/entitlements.plist` enables:
 
-- `allow-unsigned-executable-memory` — required because the Go runtime allocates executable memory
-- `disable-library-validation` — required for Go's dynamic library loading
+- `com.apple.security.cs.allow-unsigned-executable-memory` — required because the Go runtime allocates executable memory
+- `com.apple.security.cs.disable-library-validation` — required for Go's dynamic loading of system libraries
 
-### Verify Signing
+### Verify signing
 
 ```bash
 codesign --verify --deep --strict --verbose=2 "CC Daily Use Bar.app"
 ```
 
-## Notarization
+## Notarization (App Store Connect API key)
 
-### Store Credentials (one-time setup)
+This is what CI uses. The legacy `notarytool store-credentials` /
+`--keychain-profile` flow still works for one-off local runs but isn't
+documented here — see `xcrun notarytool store-credentials --help`.
 
-```bash
-xcrun notarytool store-credentials "CC_DAILYUSE_BAR" \
-  --apple-id "your@email.com" \
-  --team-id "TEAM_ID"
-```
-
-You'll be prompted for an app-specific password (generate at appleid.apple.com).
-
-### Create a ZIP for Submission
+### Submit the .app for notarization
 
 ```bash
 ditto -c -k --keepParent "CC Daily Use Bar.app" "CC Daily Use Bar.zip"
-```
 
-### Submit for Notarization
-
-```bash
 xcrun notarytool submit "CC Daily Use Bar.zip" \
-  --keychain-profile "CC_DAILYUSE_BAR" \
+  --key   /path/to/AuthKey_XXXXXXXXXX.p8 \
+  --key-id "$AC_API_KEY_ID" \
+  --issuer "$AC_API_ISSUER_ID" \
   --wait
 ```
 
-### Staple the Ticket
+`--wait` blocks until Apple finishes (typically 1-3 minutes). On success the
+final line says `status: Accepted`. On failure, run
+`xcrun notarytool log <submission-id> --key ... --key-id ... --issuer ...` to
+see what tripped.
 
-After successful notarization, staple the ticket for offline verification:
+### Staple the ticket
+
+After acceptance, embed the notarization ticket so Gatekeeper can verify offline:
 
 ```bash
 xcrun stapler staple "CC Daily Use Bar.app"
 ```
 
-### Verify Notarization
+### Verify notarization
 
 ```bash
 spctl --assess --type exec --verbose=2 "CC Daily Use Bar.app"
+xcrun stapler validate "CC Daily Use Bar.app"
 ```
 
-Expected output: `CC Daily Use Bar.app: accepted`
+Expected: `accepted source=Notarized Developer ID` and
+`The validate action worked!`.
 
-## Gatekeeper Notes
+## Build, sign, and notarize the DMG
 
-- **Unsigned binaries** will trigger "cannot be opened because the developer cannot be verified" on macOS 10.15+
-- **Signed but not notarized** binaries will trigger a warning dialog that users can bypass
-- **Signed and notarized** binaries open without any warnings
+```bash
+make dmg-macos
 
-## Ad-hoc Signing (for local development)
+DMG=$(ls dist/cc-dailyuse-bar_*_universal.dmg)
+codesign --force --timestamp --sign "Developer ID Application: YOUR_NAME (TEAM_ID)" "$DMG"
+
+xcrun notarytool submit "$DMG" \
+  --key   /path/to/AuthKey_XXXXXXXXXX.p8 \
+  --key-id "$AC_API_KEY_ID" \
+  --issuer "$AC_API_ISSUER_ID" \
+  --wait
+
+xcrun stapler staple "$DMG"
+```
+
+Notarizing both the .app and the DMG is belt-and-braces — the .app's stapled
+ticket guarantees offline acceptance after the DMG is unpacked, and the DMG's
+ticket means Gatekeeper accepts the disk image itself without an internet check.
+
+## Gatekeeper notes
+
+- **Unsigned binaries** trigger "cannot be opened because the developer cannot be verified" on macOS 10.15+
+- **Signed but not notarized** binaries trigger a bypassable warning dialog
+- **Signed and notarized** (and stapled) binaries open without any warnings, even offline
+
+## Ad-hoc signing (for local development)
 
 For local testing without a Developer ID certificate:
 
@@ -97,4 +128,4 @@ For local testing without a Developer ID certificate:
 codesign --deep --force --sign - "CC Daily Use Bar.app"
 ```
 
-This won't pass Gatekeeper but is useful for local development and testing.
+This won't pass Gatekeeper but is fine for spot-checking the bundle layout.

--- a/packaging/macos/entitlements.plist
+++ b/packaging/macos/entitlements.plist
@@ -6,5 +6,9 @@
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
 
+    <!-- Required because Go's runtime can dlopen system libraries that aren't
+         signed by the same Team ID -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

* Adds a tag-triggered (and `workflow_dispatch`-able) release workflow that imports the Developer ID Application certificate, builds the universal Mach-O via goreleaser, bundles `.app`, codesigns + notarizes + staples both the `.app` and the DMG, then publishes via goreleaser's release pass.
* Closes the gap where `.goreleaser.yaml:50` referenced a DMG (`./dist/cc-dailyuse-bar_*_universal.dmg`) that nothing in the repo actually built — so the first `goreleaser release` would have failed regardless of signing.
* Switches `packaging/macos/SIGNING.md` from the legacy app-specific-password / `--keychain-profile` notarization flow to the App Store Connect API key flow (`--key` / `--key-id` / `--issuer`), which is what CI now uses; also fixes a discrepancy where the doc claimed `disable-library-validation` was set in the entitlements plist but the key was actually missing.

## Why

Without signing + notarization, every user gets a Gatekeeper warning on first launch and `brew install --cask` refuses the artifact on recent macOS — blocking the planned Homebrew cask distribution via `petems/homebrew-tap`. The cert (Developer ID Application: PETER MORLEY-SOUTER, Team ID `C525F5TLQK`) and an App Store Connect API key (Team Key, Developer role) have been provisioned, and all 7 GitHub Actions secrets are already set on the repo: `MACOS_CERTIFICATE`, `MACOS_CERTIFICATE_PWD`, `MACOS_CERTIFICATE_NAME`, `APPLE_TEAM_ID`, `AC_API_KEY`, `AC_API_KEY_ID`, `AC_API_ISSUER_ID`.

## Files changed

- `.github/workflows/release.yml` *(new)* — release pipeline
- `Makefile` — `bundle-macos` accepts `BINARY_PATH=` override and `sed`-stamps version placeholders; new `dmg-macos` target wraps `create-dmg`
- `packaging/macos/Info.plist` — `CFBundleVersion` / `CFBundleShortVersionString` are now `__CFBUNDLE_VERSION__` / `__CFBUNDLE_SHORT_VERSION__` placeholders, substituted at bundle time
- `packaging/macos/entitlements.plist` — adds the missing `com.apple.security.cs.disable-library-validation` key
- `packaging/macos/SIGNING.md` — rewritten for the API-key flow

## Test plan

Pre-merge (already done):
- [x] `plutil -lint` clean on both plist files
- [x] `python3 -c 'yaml.safe_load(...)'` parses `release.yml`
- [x] `make -n bundle-macos VERSION=v0.1.0` and `make -n dmg-macos VERSION=v0.1.0` dry-runs render with `v` correctly stripped
- [x] Existing `ci.yml` should still pass (no Go source changes)

Post-merge (needs you to drive):
- [ ] Trigger `release.yml` via the Actions tab → `workflow_dispatch` on `master`. Should produce signed + stapled `.app` and DMG as workflow artifacts; `spctl --assess` and `xcrun stapler validate` assertions in the workflow must pass.
- [ ] Push a throwaway tag `git tag v0.0.0-test1 && git push origin v0.0.0-test1` to exercise the publish path; delete the resulting release after.
- [ ] Download the DMG on a clean Mac (or one that's never seen this app), drag the `.app` to /Applications, launch — should open with no Gatekeeper warning.
- [ ] Cut a real `v0.X.Y` tag once the dry-run + throwaway tag are both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated macOS release pipeline: builds universal binaries, signs & notarizes app and universal DMG, staples artifacts, and publishes or archives releases.

* **Documentation**
  * Updated macOS signing guide: API-key notarization, timestamped signing, DMG signing/notarization/stapling, and expanded verification/troubleshooting.

* **Chores**
  * Packaging: dynamic version injection, overridable binary path, Info.plist version placeholders, hardened-runtime entitlement added; CI workflows pinned and runners updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->