### PR TITLE
fix(release): stop deleting signing keychain in our cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,14 +145,14 @@ jobs:
           spctl --assess --type open --context context:primary-signature -vv "$DMG"
           xcrun stapler validate "$DMG"
 
-      # Drop the .p8 + signing keychain as soon as verification passes so later
+      # Drop the App Store Connect .p8 as soon as verification passes so later
       # steps (goreleaser publish, artifact upload, future cask push) can't
-      # inherit secrets they don't need. The trailing `if: always()` cleanup
-      # below covers failure paths where this step never runs.
+      # read it. The signing keychain itself is owned by
+      # apple-actions/import-codesign-certs — its post-action hook deletes the
+      # keychain at job-end, so we deliberately don't touch it here (early
+      # delete here would race the post-hook and fail it with exit code 50).
       - name: Cleanup signing material (early)
-        run: |
-          rm -f "$AC_API_KEY_PATH"
-          security delete-keychain signing_temp.keychain
+        run: rm -f "$AC_API_KEY_PATH"
 
       # Second goreleaser pass: archive + GitHub release. release.extra_files in
       # .goreleaser.yaml picks up the signed+notarized DMG. Only run on real tags.
@@ -181,11 +181,9 @@ jobs:
       # signed DMG flow is verified end-to-end. See comment block at
       # .goreleaser.yaml:39-43 for context. Requires HOMEBREW_TAP_TOKEN secret.
 
-      # Fallback cleanup for failure paths where the early cleanup never ran.
-      # `|| true` is intentional here so this step doesn't mask the real
-      # failure when the keychain / .p8 are already gone.
+      # Fallback for failure paths where the early cleanup never ran.
+      # The signing keychain is cleaned by apple-actions/import-codesign-certs'
+      # own post-action hook, so we only need to cover the .p8 here.
       - name: Cleanup signing material (fallback)
         if: always()
-        run: |
-          rm -f "$AC_API_KEY_PATH" || true
-          security delete-keychain signing_temp.keychain || true
+        run: rm -f "$AC_API_KEY_PATH" || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,9 +181,11 @@ jobs:
       # signed DMG flow is verified end-to-end. See comment block at
       # .goreleaser.yaml:39-43 for context. Requires HOMEBREW_TAP_TOKEN secret.
 
-      # Fallback for failure paths where the early cleanup never ran.
-      # The signing keychain is cleaned by apple-actions/import-codesign-certs'
-      # own post-action hook, so we only need to cover the .p8 here.
-      - name: Cleanup signing material (fallback)
+      # Always-run final .p8 cleanup. No-op on the success path (the early
+      # step already removed the file); covers failure paths where the early
+      # step never ran. The signing keychain itself is cleaned by
+      # apple-actions/import-codesign-certs' own post-action hook, so we
+      # only handle the .p8 here.
+      - name: Cleanup signing material (final)
         if: always()
         run: rm -f "$AC_API_KEY_PATH" || true


### PR DESCRIPTION
## Summary

* First dispatch dry-run (run [25142457390](https://github.com/petems/cc-dailyuse-bar/actions/runs/25142457390)) — every signing/notarization step **succeeded**, the signed+stapled DMG was produced and uploaded as the workflow artifact. Only the action's post-hook then errored.
* Failure log: `security: SecKeychainDelete: The specified keychain could not be found` → exit 50, from `apple-actions/import-codesign-certs`'s post-action hook trying to clean up `signing_temp.keychain` after our explicit early cleanup had already deleted it.
* Fix: drop the `security delete-keychain` from both the early and fallback cleanup steps. The action owns the keychain — its post-hook handles it. Keep the `.p8` deletion (the action doesn't manage that file).

## Why

The defense-in-depth review that introduced the early cleanup (commit `2ce9b32`) was right about the .p8 — that file lingers in `$RUNNER_TEMP/keys/AuthKey.p8` past verification and we want it gone. But the keychain is created by `apple-actions/import-codesign-certs` and cleaned up by its own post-hook; deleting it ourselves races the post-hook.

## Test plan

- [ ] Trigger `workflow_dispatch` on this branch via Actions tab (release.yml will be picked up from the chosen branch). Should now finish entirely green.
- [ ] Confirm the `macos-release-dryrun` artifact is uploaded as before.
- [ ] Spot-check the post-hook's log line — should now show successful `delete-keychain` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release workflow signing and cleanup to increase reliability and prevent race conditions during asset signing.
  * Simplified cleanup steps to avoid removing temporary signing material prematurely, ensuring post-signing steps complete successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->