### PR TITLE
fix(release): stash signed DMG outside dist/ so pass 2 can clean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,15 @@ jobs:
           spctl --assess --type open --context context:primary-signature -vv "$DMG"
           xcrun stapler validate "$DMG"
 
+      # Stash the signed/notarized/stapled DMG outside dist/ so the second
+      # goreleaser pass can use --clean (which wipes dist/) without losing it.
+      # extra_files in .goreleaser.yaml is configured to pick it up from here.
+      - name: Stash signed DMG outside dist/
+        run: |
+          mkdir -p .signed-output
+          cp dist/cc-dailyuse-bar_*_universal.dmg .signed-output/
+          ls -la .signed-output/
+
       # Drop the App Store Connect .p8 as soon as verification passes so later
       # steps (goreleaser publish, artifact upload, future cask push) can't
       # read it. The signing keychain itself is owned by
@@ -154,14 +163,17 @@ jobs:
       - name: Cleanup signing material (early)
         run: rm -f "$AC_API_KEY_PATH"
 
-      # Second goreleaser pass: archive + GitHub release. release.extra_files in
-      # .goreleaser.yaml picks up the signed+notarized DMG. Only run on real tags.
+      # Second goreleaser pass: archive + GitHub release. Uses --clean because
+      # goreleaser refuses to start with a non-empty dist/. This wipes the
+      # universal binary the first pass built (rebuilt here, ~30s extra) but
+      # the signed DMG is safe in .signed-output/ and gets attached via
+      # extra_files. Only run on real tags.
       - name: GoReleaser — release
         if: env.IS_TAG == 'true'
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
         with:
           version: ${{ env.GORELEASER_VERSION }}
-          args: release --clean=false
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ dist/
 
 # Console build target output (`make build-console`); local debugging artifact.
 cc-dailyuse-bar-console
+
+# Holding area for the signed/notarized/stapled DMG that the release workflow
+# stashes outside dist/ so the second goreleaser pass can run with --clean.
+.signed-output/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,11 +43,14 @@ archives:
 # and pushes a hand-templated cask file to petems/homebrew-tap.
 
 release:
-  # Narrow glob so only the current run's universal DMG attaches; avoids picking
-  # up stale artifacts if dist/ was not cleaned. The release workflow also runs
-  # `goreleaser release --clean` which wipes dist/ anyway, but defense in depth.
+  # The signed+notarized+stapled DMG is staged here by the release workflow,
+  # OUTSIDE of dist/. Reason: the release pipeline runs goreleaser twice
+  # (build → external sign/notarize → release). The second pass uses
+  # `--clean` (which wipes dist/) because goreleaser refuses to start with
+  # a non-empty dist/ otherwise; if the DMG lived in dist/, --clean would
+  # delete it before extra_files could attach it.
   extra_files:
-    - glob: ./dist/cc-dailyuse-bar_*_universal.dmg
+    - glob: ./.signed-output/cc-dailyuse-bar_*_universal.dmg
 
 changelog:
   sort: asc


### PR DESCRIPTION
## Summary

Second `v0.1.0` retry ([run 25143922584](https://github.com/petems/cc-dailyuse-bar/actions/runs/25143922584)) signed/notarized/stapled both the .app and DMG cleanly, then failed at publish:

```
release failed after 0s
error=dist is not empty, remove it before running goreleaser or use the --clean flag
```

* `--clean=false` (what we had) does NOT bypass this precondition check — the check is independent of `--clean`. We can either start with `dist/` empty or pass `--clean` to wipe it.
* `--clean` would delete the signed DMG before `extra_files` could attach it. So neither option works directly.

**Fix**: stage the signed DMG in `.signed-output/` (outside `dist/`) after stapling. Switch pass 2 to `--clean`. Update `extra_files` glob in `.goreleaser.yaml`. The DMG survives the wipe; `--clean` is happy to start.

## Files changed

- `.goreleaser.yaml` — extra_files glob: `./dist/cc-dailyuse-bar_*_universal.dmg` → `./.signed-output/cc-dailyuse-bar_*_universal.dmg`. Updated explanatory comment.
- `.github/workflows/release.yml` — new "Stash signed DMG outside dist/" step (`cp dist/...dmg .signed-output/`) right before the early `.p8` cleanup. Pass 2 args: `release --clean=false` → `release --clean`.
- `.gitignore` — adds `.signed-output/`.

## Trade-off

Pass 2 with `--clean` wipes the universal Mach-O that pass 1 lipo'd, so it gets rebuilt from scratch (~30s extra runtime). Acceptable given the simplicity of the fix; the alternative (skip pass 1 entirely, do the bundle/sign/notarize from a manually-built universal) would duplicate goreleaser's build config in shell.

## Test plan

- [ ] Land this PR.
- [ ] Delete the failed `v0.1.0` tag (local + remote).
- [ ] Re-tag `v0.1.0` on the post-merge master.
- [ ] Push tag → release.yml should now go fully green and create the GitHub Release with the stapled DMG attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the release workflow to improve handling of signed and notarized builds for better artifact management and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->