### PR TITLE
feat(release): push Homebrew cask to petems/homebrew-tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,12 @@ permissions:
   contents: write
 
 concurrency:
-  group: release-${{ github.ref }}
+  # Serialize ALL release runs (across tags + workflow_dispatch). The cask push
+  # step writes to a shared branch on petems/homebrew-tap, so two tags running
+  # in parallel could race and produce non-fast-forward push failures or stale
+  # cask updates. Constant group name + cancel-in-progress: false makes
+  # subsequent runs queue and wait their turn.
+  group: release-publish
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,7 +203,18 @@ jobs:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           set -euo pipefail
-          DMG=$(ls .signed-output/cc-dailyuse-bar_*_universal.dmg)
+
+          # Assert exactly one signed DMG before hashing — guards against a
+          # stale or duplicated artifact silently producing a wrong checksum.
+          shopt -s nullglob
+          dmgs=(.signed-output/cc-dailyuse-bar_*_universal.dmg)
+          shopt -u nullglob
+          if [[ ${#dmgs[@]} -ne 1 ]]; then
+            echo "::error::Expected exactly 1 signed DMG in .signed-output/, found ${#dmgs[@]}" >&2
+            ls -la .signed-output/ >&2 || true
+            exit 1
+          fi
+          DMG="${dmgs[0]}"
           SHA256=$(shasum -a 256 "$DMG" | awk '{print $1}')
           echo "Cask version=${VERSION} sha256=${SHA256}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,9 +189,48 @@ jobs:
             dist/cc-dailyuse-bar_*_universal.dmg
           if-no-files-found: error
 
-      # TODO: push a hand-templated cask file to petems/homebrew-tap once the
-      # signed DMG flow is verified end-to-end. See comment block at
-      # .goreleaser.yaml:39-43 for context. Requires HOMEBREW_TAP_TOKEN secret.
+      # Push a sed-templated Homebrew cask file to petems/homebrew-tap. Only
+      # runs on real tag pushes. The signed/notarized/stapled DMG lives in
+      # .signed-output/ (see "Stash signed DMG outside dist/" step). The
+      # template at packaging/homebrew/cc-dailyuse-bar.rb.tmpl uses __VERSION__
+      # and __SHA256__ placeholders. Why we don't use goreleaser's
+      # `homebrew_casks` block: see comment at .goreleaser.yaml:39-43.
+      # Requires HOMEBREW_TAP_TOKEN — fine-grained PAT with Contents:write
+      # on petems/homebrew-tap.
+      - name: Push cask to petems/homebrew-tap
+        if: env.IS_TAG == 'true'
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          DMG=$(ls .signed-output/cc-dailyuse-bar_*_universal.dmg)
+          SHA256=$(shasum -a 256 "$DMG" | awk '{print $1}')
+          echo "Cask version=${VERSION} sha256=${SHA256}"
+
+          TAPDIR="$RUNNER_TEMP/homebrew-tap"
+          git clone --depth=1 \
+            "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/petems/homebrew-tap.git" \
+            "$TAPDIR"
+
+          mkdir -p "$TAPDIR/Casks"
+          sed -e "s|__VERSION__|${VERSION}|g" \
+              -e "s|__SHA256__|${SHA256}|g" \
+              packaging/homebrew/cc-dailyuse-bar.rb.tmpl \
+            > "$TAPDIR/Casks/cc-dailyuse-bar.rb"
+
+          cd "$TAPDIR"
+          git config user.email "actions@github.com"
+          git config user.name  "github-actions[bot]"
+          git add Casks/cc-dailyuse-bar.rb
+
+          # Idempotent: if the cask already matches (e.g. a release retry),
+          # don't create an empty commit.
+          if git diff --staged --quiet; then
+            echo "Cask file unchanged; nothing to push."
+          else
+            git commit -m "cc-dailyuse-bar ${VERSION}"
+            git push origin HEAD:master
+          fi
 
       # Always-run final .p8 cleanup. No-op on the success path (the early
       # step already removed the file); covers failure paths where the early

--- a/packaging/homebrew/cc-dailyuse-bar.rb.tmpl
+++ b/packaging/homebrew/cc-dailyuse-bar.rb.tmpl
@@ -18,10 +18,10 @@ cask "cc-dailyuse-bar" do
   app "CC Daily Use Bar.app"
   binary "#{appdir}/CC Daily Use Bar.app/Contents/MacOS/cc-dailyuse-bar"
 
-  uninstall launchctl: "com.cc-dailyuse-bar"
+  uninstall launchctl: "com.cc-dailyuse-bar",
+            delete:    "~/Library/LaunchAgents/com.cc-dailyuse-bar.plist"
 
   zap trash: [
-    "~/Library/LaunchAgents/com.cc-dailyuse-bar.plist",
     "~/Library/Logs/cc-dailyuse-bar",
     "~/Library/Application Support/cc-dailyuse-bar",
     "~/Library/Preferences/com.cc-dailyuse-bar.plist",
@@ -31,7 +31,11 @@ cask "cc-dailyuse-bar" do
     To enable autostart at login, run:
       cc-dailyuse-bar service install
 
-    To disable autostart later:
+    `brew uninstall --cask` removes the autostart LaunchAgent plist, so after
+    `brew upgrade --cask cc-dailyuse-bar` you'll need to re-run the install
+    command above to restore autostart.
+
+    To disable autostart manually:
       cc-dailyuse-bar service uninstall
   EOS
 end

--- a/packaging/homebrew/cc-dailyuse-bar.rb.tmpl
+++ b/packaging/homebrew/cc-dailyuse-bar.rb.tmpl
@@ -1,0 +1,37 @@
+cask "cc-dailyuse-bar" do
+  version "__VERSION__"
+  sha256 "__SHA256__"
+
+  url "https://github.com/petems/cc-dailyuse-bar/releases/download/v#{version}/cc-dailyuse-bar_#{version}_universal.dmg",
+      verified: "github.com/petems/cc-dailyuse-bar/"
+  name "CC Daily Use Bar"
+  desc "Menu bar app for monitoring Anthropic Claude Code usage"
+  homepage "https://github.com/petems/cc-dailyuse-bar"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :monterey"
+
+  app "CC Daily Use Bar.app"
+  binary "#{appdir}/CC Daily Use Bar.app/Contents/MacOS/cc-dailyuse-bar"
+
+  uninstall launchctl: "com.cc-dailyuse-bar"
+
+  zap trash: [
+    "~/Library/LaunchAgents/com.cc-dailyuse-bar.plist",
+    "~/Library/Logs/cc-dailyuse-bar",
+    "~/Library/Application Support/cc-dailyuse-bar",
+    "~/Library/Preferences/com.cc-dailyuse-bar.plist",
+  ]
+
+  caveats <<~EOS
+    To enable autostart at login, run:
+      cc-dailyuse-bar service install
+
+    To disable autostart later:
+      cc-dailyuse-bar service uninstall
+  EOS
+end


### PR DESCRIPTION
## Summary

Replaces the TODO at `release.yml:192-194` with the real cask push step that completes the Homebrew distribution path.

* Adds **`packaging/homebrew/cc-dailyuse-bar.rb.tmpl`** — sed-templated cask file with `__VERSION__` / `__SHA256__` placeholders. Stanzas: `version`, `sha256`, `url`, `name`, `desc`, `homepage`, `livecheck` (github_latest), `depends_on macos: ">= :monterey"`, `app`, `binary` (puts `cc-dailyuse-bar` on `$PATH` so the autostart subcommand from #27 just works), `uninstall launchctl: "com.cc-dailyuse-bar"`, `zap trash:` for full cleanup, and `caveats` pointing at `cc-dailyuse-bar service install`.
* Adds **`Push cask to petems/homebrew-tap`** workflow step — gated `if: env.IS_TAG == 'true'`. Computes DMG sha256 from `.signed-output/`, clones the tap repo via `HOMEBREW_TAP_TOKEN`, sed-templates the cask, commits + pushes. Idempotent: a release retry against the same tag produces an unchanged file and skips the commit.

This is **PR 2 of 2** for the Homebrew distribution work. PR #27 (the `service` subcommand the cask caveats reference) is the prerequisite.

## Why this works the way it does

The OSS GoReleaser comment at `.goreleaser.yaml:39-43` already explains why we don't use `homebrew_casks` — it generates a `binary` stanza but we ship a DMG-delivered `.app` and need the `app:` stanza, which is GoReleaser Pro-only. So the workflow does it manually.

## Required GitHub secret (action item)

Before tagging `v0.1.1`, this needs to be in place:

- **`HOMEBREW_TAP_TOKEN`** — fine-grained PAT scoped to `petems/homebrew-tap` only, with **Contents: Read and write**. Create at https://github.com/settings/personal-access-tokens/new, then `gh secret set HOMEBREW_TAP_TOKEN --repo petems/cc-dailyuse-bar`.

The workflow step won't fire on workflow_dispatch dry-runs (gated on `IS_TAG`), so this PR can land and CI stay green even before the secret exists. The first real exercise is when v0.1.1 (or whatever the next tag is) gets pushed.

## Test plan

- [ ] Land PR #27 first (the `service` subcommand the cask references).
- [ ] Land this PR.
- [ ] Create `HOMEBREW_TAP_TOKEN` secret.
- [ ] `git tag v0.1.1 && git push origin v0.1.1`. Watch run — the new "Push cask to petems/homebrew-tap" step should succeed.
- [ ] Verify cask landed:  
  `gh repo clone petems/homebrew-tap /tmp/check && cat /tmp/check/Casks/cc-dailyuse-bar.rb` — version + sha256 should match the new release.
- [ ] On a clean Mac (or fresh user account):
  ```
  brew tap petems/tap
  brew install --cask cc-dailyuse-bar
  cc-dailyuse-bar version           # → 0.1.1
  cc-dailyuse-bar service install   # menu bar icon appears
  ```
  Logout/login → menu bar icon reappears (autostart works end-to-end).
- [ ] `brew uninstall --cask cc-dailyuse-bar` (LaunchAgent unloads via `uninstall launchctl:`); `brew uninstall --cask --zap` removes plist + logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App is now installable via a Homebrew cask (template added; includes install, uninstall, zap, and autostart caveats).

* **Chores**
  * Release workflow enhanced to serialize/preserve publish runs, publish only on tag releases, verify artifact integrity (SHA-256) before publishing, and avoid empty commits by skipping publish when no changes are detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->