### PR TITLE
fix(cmd): handle stripped PATH for ccusage in .app

### DIFF
--- a/src/cmd/applog_darwin.go
+++ b/src/cmd/applog_darwin.go
@@ -1,0 +1,67 @@
+//go:build darwin
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"cc-dailyuse-bar/src/lib"
+)
+
+// appLogPath returns the absolute path of the application log file used by
+// setupAppLogFile and read by the `logs` subcommand. Empty string means the
+// home dir could not be resolved.
+func appLogPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, "Library", "Logs", "cc-dailyuse-bar", "stderr.log")
+}
+
+// setupAppLogFile redirects stderr (and stdout, and the structured logger)
+// into ~/Library/Logs/cc-dailyuse-bar/stderr.log when running on macOS as a
+// GUI .app bundle. LaunchServices wires GUI fds to /dev/null, so without
+// this the structured logger has nowhere to write and Unknown-status issues
+// are impossible to diagnose post-hoc.
+//
+// No-op when stderr is already a regular file — the LaunchAgent plist's
+// StandardErrorPath already redirects, and shell users may have their own
+// redirect — so we don't double-write or fight the existing target.
+func setupAppLogFile() (string, error) {
+	if info, err := os.Stderr.Stat(); err == nil && info.Mode().IsRegular() {
+		return "", nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+
+	dir := filepath.Join(home, "Library", "Logs", "cc-dailyuse-bar")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("create logs dir %q: %w", dir, err)
+	}
+
+	logPath := filepath.Join(dir, "stderr.log")
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return "", fmt.Errorf("open log file %q: %w", logPath, err)
+	}
+
+	// Dup2 onto fd 1/2 so Go runtime panics and any third-party stderr writes
+	// land in the same file as the structured logger output.
+	if err := syscall.Dup2(int(f.Fd()), int(os.Stderr.Fd())); err != nil {
+		_ = f.Close()
+		return "", fmt.Errorf("dup2 stderr: %w", err)
+	}
+	_ = syscall.Dup2(int(f.Fd()), int(os.Stdout.Fd()))
+
+	// Future loggers (UsageService, TrayRunner) read the global default writer
+	// at construction; updating it here means they all log to the same file.
+	lib.SetGlobalOutput(f)
+	return logPath, nil
+}

--- a/src/cmd/applog_darwin.go
+++ b/src/cmd/applog_darwin.go
@@ -38,27 +38,34 @@ func setupAppLogFile() (string, error) {
 
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("resolve home dir: %w", err)
+		return "", lib.WrapError(err, lib.ErrCodeSystem, "resolve home dir")
 	}
 
 	dir := filepath.Join(home, "Library", "Logs", "cc-dailyuse-bar")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return "", fmt.Errorf("create logs dir %q: %w", dir, err)
+	// #nosec G301 -- 0o755 lets the user read logs from Finder/Terminal without sudo; matches service.go convention
+	if mkErr := os.MkdirAll(dir, 0o755); mkErr != nil {
+		return "", lib.WrapError(mkErr, lib.ErrCodeSystem, fmt.Sprintf("create logs dir %q", dir))
 	}
 
 	logPath := filepath.Join(dir, "stderr.log")
-	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	// #nosec G304 -- logPath is derived from UserHomeDir + fixed app subpath, not user input
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
-		return "", fmt.Errorf("open log file %q: %w", logPath, err)
+		return "", lib.WrapError(err, lib.ErrCodeSystem, fmt.Sprintf("open log file %q", logPath))
 	}
 
 	// Dup2 onto fd 1/2 so Go runtime panics and any third-party stderr writes
-	// land in the same file as the structured logger output.
+	// land in the same file as the structured logger output. Treat both fds
+	// as mandatory: if stdout redirect fails we'd otherwise return success
+	// but leave the global logger pinned to a half-redirected file.
 	if err := syscall.Dup2(int(f.Fd()), int(os.Stderr.Fd())); err != nil {
 		_ = f.Close()
-		return "", fmt.Errorf("dup2 stderr: %w", err)
+		return "", lib.WrapError(err, lib.ErrCodeSystem, "dup2 stderr")
 	}
-	_ = syscall.Dup2(int(f.Fd()), int(os.Stdout.Fd()))
+	if err := syscall.Dup2(int(f.Fd()), int(os.Stdout.Fd())); err != nil {
+		_ = f.Close()
+		return "", lib.WrapError(err, lib.ErrCodeSystem, "dup2 stdout")
+	}
 
 	// Future loggers (UsageService, TrayRunner) read the global default writer
 	// at construction; updating it here means they all log to the same file.

--- a/src/cmd/applog_other.go
+++ b/src/cmd/applog_other.go
@@ -1,0 +1,16 @@
+//go:build !darwin
+
+package cmd
+
+// setupAppLogFile is a no-op outside macOS. The launchd-induced "logs vanish
+// when the .app is launched from /Applications" problem this addresses is
+// macOS-specific.
+func setupAppLogFile() (string, error) {
+	return "", nil
+}
+
+// appLogPath returns "" on non-darwin: the app log is macOS-only because the
+// LaunchAgent and LaunchServices flows that motivate it are macOS-only.
+func appLogPath() string {
+	return ""
+}

--- a/src/cmd/doctor.go
+++ b/src/cmd/doctor.go
@@ -39,7 +39,7 @@ var doctorCmd = &cobra.Command{
 		// PATH while doctor (run from a shell) reports everything fine.
 		path, fallback, err := services.ResolveCCUsagePath(config.CCUsagePath)
 		if err != nil {
-			return fmt.Errorf("binary: 'ccusage' not found at %q; install ccusage or set 'ccusage_path' to an absolute path in config", config.CCUsagePath)
+			return fmt.Errorf("binary: 'ccusage' not found at %q; install ccusage or set 'ccusage_path' to an absolute path in config: %w", config.CCUsagePath, err)
 		}
 
 		// On non-Windows, verify the file is executable via permission bits.

--- a/src/cmd/doctor.go
+++ b/src/cmd/doctor.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"runtime"
 
 	"github.com/spf13/cobra"
@@ -33,10 +32,14 @@ var doctorCmd = &cobra.Command{
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "Config: Valid (loaded from %s)\n", svc.GetConfigPath())
 
-		// 2. Binary Check
-		path, err := exec.LookPath(config.CCUsagePath)
+		// 2. Binary Check — uses the same resolver the running tray uses
+		// (PATH lookup, with macOS Homebrew fallback for bare names) so
+		// `doctor` matches runtime behaviour. Without this, the tray could
+		// fail when launched from /Applications under launchd's stripped
+		// PATH while doctor (run from a shell) reports everything fine.
+		path, fallback, err := services.ResolveCCUsagePath(config.CCUsagePath)
 		if err != nil {
-			return fmt.Errorf("binary: 'ccusage' not found at %q; install ccusage or update 'ccusage_path' in config", config.CCUsagePath)
+			return fmt.Errorf("binary: 'ccusage' not found at %q; install ccusage or set 'ccusage_path' to an absolute path in config", config.CCUsagePath)
 		}
 
 		// On non-Windows, verify the file is executable via permission bits.
@@ -52,6 +55,14 @@ var doctorCmd = &cobra.Command{
 			}
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "Binary: Found at '%s'\n", path)
+		if fallback {
+			fmt.Fprintf(cmd.OutOrStdout(),
+				"Binary: WARNING — resolved via Homebrew fallback because %q is not on PATH.\n"+
+					"        macOS .app bundles launched from /Applications run with a minimal PATH\n"+
+					"        (no /opt/homebrew/bin), so set 'ccusage_path: %s' in config to be safe.\n",
+				config.CCUsagePath, path)
+			hasWarnings = true
+		}
 
 		// 3. Connectivity Check (One-shot poll)
 		fmt.Fprintf(cmd.OutOrStdout(), "Connectivity: Testing API connection (timeout: %ds)...\n", config.CmdTimeout)

--- a/src/cmd/logs.go
+++ b/src/cmd/logs.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	logsTailLines int
+	logsFollow    bool
+)
+
+var logsCmd = &cobra.Command{
+	Use:   "logs",
+	Short: "Print the latest entries from the application log",
+	Long: `Print the tail of the cc-dailyuse-bar log file.
+
+Useful when the menu bar shows "Unknown" or another unexpected state — the
+structured logs explain why ccusage failed (path lookup, JSON parse, timeout,
+etc.). On macOS the log lives at ~/Library/Logs/cc-dailyuse-bar/stderr.log
+and is written both by the LaunchAgent (when installed via 'service install')
+and by the .app bundle itself (since it now redirects its own stderr).`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		path := appLogPath()
+		if path == "" {
+			return errors.New("logs: application log file is only available on macOS")
+		}
+
+		out := cmd.OutOrStdout()
+
+		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+			fmt.Fprintf(out, "No log file at %s yet.\n", path)
+			fmt.Fprintln(out, "The log is created the first time the app runs (either via the menu bar or 'cc-dailyuse-bar service install').")
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("logs: stat %q: %w", path, err)
+		}
+
+		if err := printTail(out, path, logsTailLines); err != nil {
+			return err
+		}
+
+		if !logsFollow {
+			return nil
+		}
+		return followFile(cmd.Context(), out, path)
+	},
+}
+
+func init() {
+	logsCmd.Flags().IntVarP(&logsTailLines, "tail", "n", 50, "number of lines from the end of the log to print (0 = all)")
+	logsCmd.Flags().BoolVarP(&logsFollow, "follow", "f", false, "keep reading new lines as they're appended (like tail -f)")
+	RootCmd.AddCommand(logsCmd)
+}
+
+// printTail writes the last n lines of path to w. n <= 0 means "everything".
+// Reads the whole file; fine for the log sizes this app produces.
+func printTail(w io.Writer, path string, n int) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("logs: read %q: %w", path, err)
+	}
+	if len(data) == 0 {
+		return nil
+	}
+
+	trimmed := bytes.TrimRight(data, "\n")
+	if len(trimmed) == 0 {
+		return nil
+	}
+	lines := bytes.Split(trimmed, []byte("\n"))
+
+	if n > 0 && len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+
+	for _, line := range lines {
+		if _, err := fmt.Fprintf(w, "%s\n", line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// followFile opens path at its end and prints new lines as they appear. Exits
+// when ctx is cancelled (e.g. SIGINT via cobra's context). Doesn't handle
+// rotation — the log file is append-only in this app.
+func followFile(ctx context.Context, w io.Writer, path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("logs: open %q for follow: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := f.Seek(0, io.SeekEnd); err != nil {
+		return fmt.Errorf("logs: seek to end of %q: %w", path, err)
+	}
+
+	reader := bufio.NewReader(f)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		line, err := reader.ReadString('\n')
+		if line != "" {
+			if _, werr := fmt.Fprint(w, line); werr != nil {
+				return werr
+			}
+		}
+		if err == io.EOF {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(250 * time.Millisecond):
+			}
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("logs: read %q: %w", path, err)
+		}
+	}
+}

--- a/src/cmd/logs.go
+++ b/src/cmd/logs.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"cc-dailyuse-bar/src/lib"
 )
 
 var (
@@ -31,7 +33,7 @@ and by the .app bundle itself (since it now redirects its own stderr).`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		path := appLogPath()
 		if path == "" {
-			return errors.New("logs: application log file is only available on macOS")
+			return lib.NewError(lib.ErrCodeSystem, "logs: application log file is only available on macOS")
 		}
 
 		out := cmd.OutOrStdout()
@@ -41,7 +43,7 @@ and by the .app bundle itself (since it now redirects its own stderr).`,
 			fmt.Fprintln(out, "The log is created the first time the app runs (either via the menu bar or 'cc-dailyuse-bar service install').")
 			return nil
 		} else if err != nil {
-			return fmt.Errorf("logs: stat %q: %w", path, err)
+			return lib.WrapError(err, lib.ErrCodeSystem, fmt.Sprintf("logs: stat %q", path))
 		}
 
 		if err := printTail(out, path, logsTailLines); err != nil {
@@ -64,9 +66,10 @@ func init() {
 // printTail writes the last n lines of path to w. n <= 0 means "everything".
 // Reads the whole file; fine for the log sizes this app produces.
 func printTail(w io.Writer, path string, n int) error {
+	// #nosec G304 -- path comes from appLogPath() (UserHomeDir + fixed app subpath), not user input
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return fmt.Errorf("logs: read %q: %w", path, err)
+		return lib.WrapError(err, lib.ErrCodeSystem, fmt.Sprintf("logs: read %q", path))
 	}
 	if len(data) == 0 {
 		return nil
@@ -94,14 +97,15 @@ func printTail(w io.Writer, path string, n int) error {
 // when ctx is cancelled (e.g. SIGINT via cobra's context). Doesn't handle
 // rotation — the log file is append-only in this app.
 func followFile(ctx context.Context, w io.Writer, path string) error {
+	// #nosec G304 -- path comes from appLogPath() (UserHomeDir + fixed app subpath), not user input
 	f, err := os.Open(path)
 	if err != nil {
-		return fmt.Errorf("logs: open %q for follow: %w", path, err)
+		return lib.WrapError(err, lib.ErrCodeSystem, fmt.Sprintf("logs: open %q for follow", path))
 	}
 	defer func() { _ = f.Close() }()
 
 	if _, err := f.Seek(0, io.SeekEnd); err != nil {
-		return fmt.Errorf("logs: seek to end of %q: %w", path, err)
+		return lib.WrapError(err, lib.ErrCodeSystem, fmt.Sprintf("logs: seek to end of %q", path))
 	}
 
 	reader := bufio.NewReader(f)
@@ -127,7 +131,7 @@ func followFile(ctx context.Context, w io.Writer, path string) error {
 			continue
 		}
 		if err != nil {
-			return fmt.Errorf("logs: read %q: %w", path, err)
+			return lib.WrapError(err, lib.ErrCodeSystem, fmt.Sprintf("logs: read %q", path))
 		}
 	}
 }

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -57,6 +57,20 @@ This is the default mode if no command is specified.`,
 			return runAsDaemon(cmd)
 		}
 
+		// Redirect stderr/stdout into a known log file before any service is
+		// constructed — otherwise loggers cache the os.Stderr writer and the
+		// file redirect has no effect on them. Failures here are non-fatal:
+		// the app still works, just without persistent logs.
+		if logPath, err := setupAppLogFile(); err != nil {
+			logger.Warn("Failed to set up app log file; logs may not be captured", map[string]interface{}{
+				"error": err.Error(),
+			})
+		} else if logPath != "" {
+			logger.Info("App log file initialized", map[string]interface{}{
+				"path": logPath,
+			})
+		}
+
 		return runTrayApp(cmd, config)
 	},
 }

--- a/src/services/path_resolver.go
+++ b/src/services/path_resolver.go
@@ -1,12 +1,13 @@
 package services
 
 import (
-	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"cc-dailyuse-bar/src/lib"
 )
 
 // homebrewFallbackDirs lists Homebrew install locations searched on macOS when
@@ -25,7 +26,7 @@ var homebrewFallbackDirs = []string{
 // The fallback flag is true when LookPath failed and a Homebrew dir matched.
 func ResolveCCUsagePath(configured string) (resolved string, fallback bool, err error) {
 	if configured == "" {
-		return "", false, errors.New("ccusage path is empty")
+		return "", false, lib.ValidationError("ccusage path is empty")
 	}
 
 	if p, lookErr := exec.LookPath(configured); lookErr == nil {
@@ -37,9 +38,9 @@ func ResolveCCUsagePath(configured string) (resolved string, fallback bool, err 
 				return candidate, true, nil
 			}
 		}
-		return "", false, lookErr
+		return "", false, lib.WrapError(lookErr, lib.ErrCodeCCUsage, "ccusage not found on PATH or Homebrew fallback dirs")
 	} else {
-		return "", false, lookErr
+		return "", false, lib.WrapError(lookErr, lib.ErrCodeCCUsage, "ccusage not found on PATH")
 	}
 }
 

--- a/src/services/path_resolver.go
+++ b/src/services/path_resolver.go
@@ -1,0 +1,52 @@
+package services
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// homebrewFallbackDirs lists Homebrew install locations searched on macOS when
+// a bare ccusage name can't be found via PATH. macOS LaunchServices launches
+// .app bundles with a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin) that omits
+// these locations, so a config like `ccusage_path: ccusage` works from a
+// terminal but fails for the menu bar app. Var (not const) so tests can swap.
+var homebrewFallbackDirs = []string{
+	"/opt/homebrew/bin",
+	"/usr/local/bin",
+}
+
+// ResolveCCUsagePath returns an absolute path that exec.Command can invoke
+// for the configured ccusage location. It mirrors exec.CommandContext's PATH
+// lookup, then on macOS falls back to common Homebrew dirs for bare names.
+// The fallback flag is true when LookPath failed and a Homebrew dir matched.
+func ResolveCCUsagePath(configured string) (resolved string, fallback bool, err error) {
+	if configured == "" {
+		return "", false, errors.New("ccusage path is empty")
+	}
+
+	if p, lookErr := exec.LookPath(configured); lookErr == nil {
+		return p, false, nil
+	} else if runtime.GOOS == "darwin" && !strings.ContainsRune(configured, '/') {
+		for _, dir := range homebrewFallbackDirs {
+			candidate := filepath.Join(dir, configured)
+			if isExecutableFile(candidate) {
+				return candidate, true, nil
+			}
+		}
+		return "", false, lookErr
+	} else {
+		return "", false, lookErr
+	}
+}
+
+func isExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	return info.Mode()&0o111 != 0
+}

--- a/src/services/usage_service.go
+++ b/src/services/usage_service.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"sync"
 	"time"
@@ -160,16 +159,12 @@ func (us *UsageService) IsAvailable() bool {
 	// ResolveCCUsagePath mirrors exec.CommandContext's PATH-only lookup for
 	// bare names and adds a macOS Homebrew fallback so .app bundles launched
 	// from /Applications (with a stripped PATH) can still find ccusage.
+	// Both lookup paths (exec.LookPath and isExecutableFile) already verify
+	// the result is an executable regular file, so we trust the resolver and
+	// skip a redundant Stat — that redundant check used POSIX mode bits and
+	// would incorrectly mark valid .exe files as unavailable on Windows.
 	resolvedPath, fallback, err := ResolveCCUsagePath(us.ccusagePath)
 	if err != nil {
-		return false
-	}
-
-	info, err := os.Stat(resolvedPath)
-	if err != nil || info.IsDir() {
-		return false
-	}
-	if info.Mode()&0o111 == 0 {
 		return false
 	}
 
@@ -352,7 +347,8 @@ func (us *UsageService) executeCCUsage() ([]byte, error) {
 	// names under launchd / LaunchServices' stripped PATH.
 	resolvedPath, _, resolveErr := ResolveCCUsagePath(us.ccusagePath)
 	if resolveErr != nil {
-		return nil, fmt.Errorf("ccusage path %q could not be resolved: %w", us.ccusagePath, resolveErr)
+		return nil, lib.WrapError(resolveErr, lib.ErrCodeCCUsage,
+			fmt.Sprintf("ccusage path %q could not be resolved", us.ccusagePath))
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), us.cmdTimeout)

--- a/src/services/usage_service.go
+++ b/src/services/usage_service.go
@@ -33,6 +33,7 @@ type UsageService struct {
 	cmdTimeout      time.Duration
 	yellowThreshold float64
 	redThreshold    float64
+	fallbackLogOnce sync.Once
 }
 
 // NewUsageService creates a new UsageService instance
@@ -156,25 +157,39 @@ func (us *UsageService) IsAvailable() bool {
 		return false
 	}
 
-	// Resolve via exec.LookPath first so the availability check follows the
-	// same rules as exec.CommandContext (PATH-only for bare names, never the
-	// cwd). Otherwise IsAvailable could return true for a file in the working
-	// directory that exec would later fail to find.
-	resolvedPath, err := exec.LookPath(us.ccusagePath)
+	// ResolveCCUsagePath mirrors exec.CommandContext's PATH-only lookup for
+	// bare names and adds a macOS Homebrew fallback so .app bundles launched
+	// from /Applications (with a stripped PATH) can still find ccusage.
+	resolvedPath, fallback, err := ResolveCCUsagePath(us.ccusagePath)
 	if err != nil {
 		return false
 	}
 
 	info, err := os.Stat(resolvedPath)
-	if err != nil {
+	if err != nil || info.IsDir() {
+		return false
+	}
+	if info.Mode()&0o111 == 0 {
 		return false
 	}
 
-	if info.IsDir() {
-		return false
+	if fallback {
+		us.logFallbackOnce(resolvedPath)
 	}
+	return true
+}
 
-	return info.Mode()&0o111 != 0
+// logFallbackOnce surfaces a one-shot warning when ResolveCCUsagePath had to
+// fall back to a Homebrew dir because PATH lookup failed. Helps users notice
+// the .app-bundle PATH issue and pin ccusage_path to an absolute location.
+func (us *UsageService) logFallbackOnce(resolvedPath string) {
+	us.fallbackLogOnce.Do(func() {
+		us.logger.Warn("ccusage not found on PATH; resolved via Homebrew fallback. Set ccusage_path to an absolute path in config to silence this.",
+			map[string]interface{}{
+				"configured": us.ccusagePath,
+				"resolved":   resolvedPath,
+			})
+	})
 }
 
 // SetCCUsagePath updates the path to ccusage binary
@@ -332,10 +347,18 @@ func (us *UsageService) performUpdateLocked(maxRetries int) (*models.UsageState,
 }
 
 func (us *UsageService) executeCCUsage() ([]byte, error) {
+	// Use the resolved path so the macOS Homebrew fallback applies here too —
+	// otherwise exec.CommandContext re-runs PATH lookup and fails for bare
+	// names under launchd / LaunchServices' stripped PATH.
+	resolvedPath, _, resolveErr := ResolveCCUsagePath(us.ccusagePath)
+	if resolveErr != nil {
+		return nil, fmt.Errorf("ccusage path %q could not be resolved: %w", us.ccusagePath, resolveErr)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), us.cmdTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, us.ccusagePath, "daily", "--json")
+	cmd := exec.CommandContext(ctx, resolvedPath, "daily", "--json")
 	output, err := cmd.Output()
 	if err != nil {
 		// When the context deadline fires, Go kills the child with SIGKILL and


### PR DESCRIPTION
## Summary

* Fix `⚪️ Unknown` status when the menu bar app is launched from `/Applications`: macOS LaunchServices runs the .app with a minimal `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, so a bare `ccusage_path: ccusage` failed `exec.LookPath` even though `doctor` (running with the user's shell PATH) reported everything fine. Adds a Homebrew fallback (`/opt/homebrew/bin`, `/usr/local/bin`) for bare names on macOS, used by both `IsAvailable()` and `executeCCUsage()`.
* Redirect `.app`-launched stderr/stdout into `~/Library/Logs/cc-dailyuse-bar/stderr.log` so structured logs persist when the LaunchAgent plist isn't in play. No-op when stderr is already a regular file (e.g. the LaunchAgent's `StandardErrorPath`, or a shell redirect).
* Update `doctor` to use the same resolver as runtime — it now warns when fallback is used and prints the exact `ccusage_path:` line to paste into config.
* New `cc-dailyuse-bar logs` subcommand with `-n/--tail` (default 50) and `-f/--follow` for diagnosing future Unknown-status mysteries without `ps eww` archaeology.

Builds on the earlier resolved-path availability fix in #13.

## Test plan

- [x] `make build` — passes
- [x] `make test` — all packages green (`cmd`, `internal/tray`, `lib`, `models`, `services`)
- [x] `./cc-dailyuse-bar doctor` with absolute `ccusage_path` — passes cleanly
- [x] `./cc-dailyuse-bar doctor` with bare `ccusage_path: ccusage` under stripped PATH — prints fallback warning with paste-ready `ccusage_path: /opt/homebrew/bin/ccusage` line
- [x] `./cc-dailyuse-bar logs --tail 5` — prints the last 5 lines of the existing stderr.log
- [x] `./cc-dailyuse-bar logs --help` — flags documented
- [ ] Manual: install built binary to `/Applications/CC Daily Use Bar.app/Contents/MacOS/`, launch from Finder with bare `ccusage_path`, confirm menu bar shows a coloured status (not Unknown) and `~/Library/Logs/cc-dailyuse-bar/stderr.log` receives new entries
- [ ] Manual: `--follow` mode — confirm new lines appear in real time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a macOS-only logs command to view recent app logs and optionally stream live output.
  * macOS GUI runs now capture and persist application stdout/stderr to a user log file.

* **Improvements**
  * Smarter resolution of an external helper binary with clearer error messages and a Homebrew-path fallback on macOS.
  * Commands now surface macOS-specific warnings when PATH issues are detected and log setup problems are reported as warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/petems/cc-dailyuse-bar/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->