### PR TITLE
fix(services): ensure polling stop signals reach goroutines

### DIFF
--- a/src/cmd/run_tray.go
+++ b/src/cmd/run_tray.go
@@ -33,6 +33,7 @@ func startTrayApp(cmd *cobra.Command, config *models.Config) error {
 			"signal": sig.String(),
 		})
 		usageService.StopPolling()
+		usageService.StopDailyResetMonitor()
 		systray.Quit()
 	}()
 

--- a/src/internal/tray/runner.go
+++ b/src/internal/tray/runner.go
@@ -205,5 +205,6 @@ func (tr *Runner) onExit() {
 	// Ensure background goroutines stop cleanly
 	if tr.usageService != nil {
 		tr.usageService.StopPolling()
+		tr.usageService.StopDailyResetMonitor()
 	}
 }

--- a/src/services/usage_service.go
+++ b/src/services/usage_service.go
@@ -583,13 +583,17 @@ func (us *UsageService) pollingLoop(ticker *time.Ticker, stopChan <-chan struct{
 // StartDailyResetMonitor starts the daily reset scheduler with midnight
 // detection (T031).
 func (us *UsageService) StartDailyResetMonitor() {
-	us.StopDailyResetMonitor()
-
-	// Launch under the read lock so StopDailyResetMonitor cannot replace/close
-	// the captured stop channel between the read and the goroutine start.
-	us.mutex.RLock()
+	// Fold previous-stop and goroutine launch into one locked section so a
+	// concurrent StopDailyResetMonitor cannot slip between them and close the
+	// stop channel the new dailyResetLoop just captured. Mirrors StartPolling.
+	us.mutex.Lock()
+	oldStopChan := us.replaceStopChan(&us.resetStopChan)
 	go us.dailyResetLoop(us.resetStopChan)
-	us.mutex.RUnlock()
+	us.mutex.Unlock()
+
+	if oldStopChan != nil {
+		close(oldStopChan)
+	}
 
 	us.logger.Info("Daily reset monitor started")
 }

--- a/src/services/usage_service.go
+++ b/src/services/usage_service.go
@@ -483,18 +483,18 @@ func (us *UsageService) StartPolling(intervalSeconds int, callback func(*models.
 
 	ticker := time.NewTicker(time.Duration(intervalSeconds) * time.Second)
 
-	// Create ticker and assign callback atomically with mutex protection
+	// Launch the goroutine while still holding the mutex so a concurrent
+	// StopPolling() cannot close the captured stop channel before the loop
+	// observes it.
 	us.mutex.Lock()
 	us.updateCallback = callback
 	us.ticker = ticker
-	stopChan := us.pollStopChan
+	go us.pollingLoop(ticker, us.pollStopChan)
 	us.mutex.Unlock()
 
 	us.logger.Info("Starting usage polling", map[string]interface{}{
 		"intervalSeconds": intervalSeconds,
 	})
-
-	go us.pollingLoop(ticker, stopChan)
 
 	return nil
 }
@@ -565,11 +565,12 @@ func (us *UsageService) pollingLoop(ticker *time.Ticker, stopChan <-chan struct{
 // StartDailyResetMonitor starts the daily reset scheduler with midnight
 // detection (T031).
 func (us *UsageService) StartDailyResetMonitor() {
+	// Launch under the read lock so StopPolling cannot replace/close the
+	// captured stop channel between the read and the goroutine start.
 	us.mutex.RLock()
-	stopChan := us.resetStopChan
+	go us.dailyResetLoop(us.resetStopChan)
 	us.mutex.RUnlock()
 
-	go us.dailyResetLoop(stopChan)
 	us.logger.Info("Daily reset monitor started")
 }
 

--- a/src/services/usage_service.go
+++ b/src/services/usage_service.go
@@ -499,26 +499,38 @@ func (us *UsageService) StartPolling(intervalSeconds int, callback func(*models.
 	return nil
 }
 
-// StopPolling stops the polling timer
+// StopPolling stops the polling timer. It does NOT stop the daily reset
+// monitor — call StopDailyResetMonitor for that. Splitting them lets callers
+// restart polling (StartPolling internally calls StopPolling) without tearing
+// down a running midnight monitor.
 func (us *UsageService) StopPolling() {
 	us.mutex.Lock()
 	if us.ticker != nil {
 		us.ticker.Stop()
 		us.ticker = nil
 	}
-
 	pollStopChan := us.replaceStopChan(&us.pollStopChan)
-	resetStopChan := us.replaceStopChan(&us.resetStopChan)
 	us.mutex.Unlock()
 
 	if pollStopChan != nil {
 		close(pollStopChan)
 	}
+
+	us.logger.Info("Usage polling stopped")
+}
+
+// StopDailyResetMonitor stops the midnight detection goroutine started by
+// StartDailyResetMonitor. Idempotent.
+func (us *UsageService) StopDailyResetMonitor() {
+	us.mutex.Lock()
+	resetStopChan := us.replaceStopChan(&us.resetStopChan)
+	us.mutex.Unlock()
+
 	if resetStopChan != nil {
 		close(resetStopChan)
 	}
 
-	us.logger.Info("Usage polling stopped")
+	us.logger.Info("Daily reset monitor stopped")
 }
 
 func (us *UsageService) replaceStopChan(chPtr *chan struct{}) chan struct{} {

--- a/src/services/usage_service.go
+++ b/src/services/usage_service.go
@@ -479,18 +479,24 @@ func (us *UsageService) StartPolling(intervalSeconds int, callback func(*models.
 		return lib.ValidationError("polling interval must be positive")
 	}
 
-	us.StopPolling()
-
-	ticker := time.NewTicker(time.Duration(intervalSeconds) * time.Second)
-
-	// Launch the goroutine while still holding the mutex so a concurrent
-	// StopPolling() cannot close the captured stop channel before the loop
-	// observes it.
+	// Fold previous-stop, ticker creation, and goroutine launch into one
+	// locked section so a concurrent StopPolling cannot slip between them and
+	// close the stop channel that the new pollingLoop is about to capture.
 	us.mutex.Lock()
+	if us.ticker != nil {
+		us.ticker.Stop()
+		us.ticker = nil
+	}
+	oldStopChan := us.replaceStopChan(&us.pollStopChan)
+	ticker := time.NewTicker(time.Duration(intervalSeconds) * time.Second)
 	us.updateCallback = callback
 	us.ticker = ticker
 	go us.pollingLoop(ticker, us.pollStopChan)
 	us.mutex.Unlock()
+
+	if oldStopChan != nil {
+		close(oldStopChan)
+	}
 
 	us.logger.Info("Starting usage polling", map[string]interface{}{
 		"intervalSeconds": intervalSeconds,
@@ -577,8 +583,10 @@ func (us *UsageService) pollingLoop(ticker *time.Ticker, stopChan <-chan struct{
 // StartDailyResetMonitor starts the daily reset scheduler with midnight
 // detection (T031).
 func (us *UsageService) StartDailyResetMonitor() {
-	// Launch under the read lock so StopPolling cannot replace/close the
-	// captured stop channel between the read and the goroutine start.
+	us.StopDailyResetMonitor()
+
+	// Launch under the read lock so StopDailyResetMonitor cannot replace/close
+	// the captured stop channel between the read and the goroutine start.
 	us.mutex.RLock()
 	go us.dailyResetLoop(us.resetStopChan)
 	us.mutex.RUnlock()

--- a/src/services/usage_service.go
+++ b/src/services/usage_service.go
@@ -507,15 +507,8 @@ func (us *UsageService) StopPolling() {
 		us.ticker = nil
 	}
 
-	var pollStopChan, resetStopChan chan struct{}
-	if us.pollStopChan != nil {
-		pollStopChan = us.pollStopChan
-		us.pollStopChan = make(chan struct{})
-	}
-	if us.resetStopChan != nil {
-		resetStopChan = us.resetStopChan
-		us.resetStopChan = make(chan struct{})
-	}
+	pollStopChan := us.replaceStopChan(&us.pollStopChan)
+	resetStopChan := us.replaceStopChan(&us.resetStopChan)
 	us.mutex.Unlock()
 
 	if pollStopChan != nil {
@@ -526,6 +519,14 @@ func (us *UsageService) StopPolling() {
 	}
 
 	us.logger.Info("Usage polling stopped")
+}
+
+func (us *UsageService) replaceStopChan(chPtr *chan struct{}) chan struct{} {
+	oldChan := *chPtr
+	if oldChan != nil {
+		*chPtr = make(chan struct{})
+	}
+	return oldChan
 }
 
 // pollingLoop runs the polling loop in a goroutine

--- a/src/services/usage_service.go
+++ b/src/services/usage_service.go
@@ -481,52 +481,59 @@ func (us *UsageService) StartPolling(intervalSeconds int, callback func(*models.
 
 	us.StopPolling()
 
+	ticker := time.NewTicker(time.Duration(intervalSeconds) * time.Second)
+
 	// Create ticker and assign callback atomically with mutex protection
 	us.mutex.Lock()
 	us.updateCallback = callback
-	us.ticker = time.NewTicker(time.Duration(intervalSeconds) * time.Second)
+	us.ticker = ticker
+	stopChan := us.pollStopChan
 	us.mutex.Unlock()
 
 	us.logger.Info("Starting usage polling", map[string]interface{}{
 		"intervalSeconds": intervalSeconds,
 	})
 
-	go us.pollingLoop()
+	go us.pollingLoop(ticker, stopChan)
 
 	return nil
 }
 
 // StopPolling stops the polling timer
 func (us *UsageService) StopPolling() {
-	select {
-	case us.pollStopChan <- struct{}{}:
-	default:
-	}
-	select {
-	case us.resetStopChan <- struct{}{}:
-	default:
-	}
-
 	us.mutex.Lock()
 	if us.ticker != nil {
 		us.ticker.Stop()
 		us.ticker = nil
 	}
+
+	var pollStopChan, resetStopChan chan struct{}
+	if us.pollStopChan != nil {
+		pollStopChan = us.pollStopChan
+		us.pollStopChan = make(chan struct{})
+	}
+	if us.resetStopChan != nil {
+		resetStopChan = us.resetStopChan
+		us.resetStopChan = make(chan struct{})
+	}
 	us.mutex.Unlock()
+
+	if pollStopChan != nil {
+		close(pollStopChan)
+	}
+	if resetStopChan != nil {
+		close(resetStopChan)
+	}
 
 	us.logger.Info("Usage polling stopped")
 }
 
 // pollingLoop runs the polling loop in a goroutine
-func (us *UsageService) pollingLoop() {
-	us.mutex.RLock()
-	if us.ticker == nil {
-		us.mutex.RUnlock()
+func (us *UsageService) pollingLoop(ticker *time.Ticker, stopChan <-chan struct{}) {
+	if ticker == nil {
 		us.logger.Error("Polling loop started without ticker")
 		return
 	}
-	ticker := us.ticker
-	us.mutex.RUnlock()
 
 	for {
 		select {
@@ -547,7 +554,7 @@ func (us *UsageService) pollingLoop() {
 				callback(state)
 			}
 
-		case <-us.pollStopChan:
+		case <-stopChan:
 			us.logger.Debug("Polling loop stopped")
 			return
 		}
@@ -557,12 +564,16 @@ func (us *UsageService) pollingLoop() {
 // StartDailyResetMonitor starts the daily reset scheduler with midnight
 // detection (T031).
 func (us *UsageService) StartDailyResetMonitor() {
-	go us.dailyResetLoop()
+	us.mutex.RLock()
+	stopChan := us.resetStopChan
+	us.mutex.RUnlock()
+
+	go us.dailyResetLoop(stopChan)
 	us.logger.Info("Daily reset monitor started")
 }
 
 // dailyResetLoop monitors for midnight and resets daily counters
-func (us *UsageService) dailyResetLoop() {
+func (us *UsageService) dailyResetLoop(stopChan <-chan struct{}) {
 	lastResetDay := time.Now().Day()
 	resetChecker := time.NewTicker(1 * time.Minute)
 	defer resetChecker.Stop()
@@ -594,7 +605,7 @@ func (us *UsageService) dailyResetLoop() {
 				lastResetDay = now.Day()
 			}
 
-		case <-us.resetStopChan:
+		case <-stopChan:
 			us.logger.Debug("Daily reset loop stopped")
 			return
 		}

--- a/src/services/usage_service_test.go
+++ b/src/services/usage_service_test.go
@@ -412,6 +412,7 @@ func TestUsageService_StartDailyResetMonitor(t *testing.T) {
 
 	// Ensure clean state
 	service.StopPolling()
+	service.StopDailyResetMonitor()
 
 	// Set some data
 	service.state.DailyCount = 100
@@ -423,8 +424,10 @@ func TestUsageService_StartDailyResetMonitor(t *testing.T) {
 	// Wait a bit
 	time.Sleep(100 * time.Millisecond)
 
-	// Stop the service gracefully
+	// Stop the service gracefully — explicitly stop the reset monitor so it
+	// doesn't leak into later tests' goroutine baselines.
 	service.StopPolling()
+	service.StopDailyResetMonitor()
 }
 
 // TestUsageService_PollingRestart verifies that StartPolling -> StopPolling ->

--- a/src/services/usage_service_test.go
+++ b/src/services/usage_service_test.go
@@ -6,21 +6,48 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
+
+	"cc-dailyuse-bar/src/models"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"cc-dailyuse-bar/src/lib"
-	"cc-dailyuse-bar/src/models"
 )
 
 // Helper function to create a usage service with default config
 func newTestUsageService() *UsageService {
 	config := models.ConfigDefaults()
 	return NewUsageService(config)
+}
+
+// waitForStableGoroutineCount polls runtime.NumGoroutine() until it returns
+// the same value across `stableFor` consecutive samples (10ms apart) or
+// `timeout` elapses, then returns that value. Used to capture a clean
+// "idle" baseline that isn't polluted by goroutines from earlier tests
+// still in the process of exiting.
+func waitForStableGoroutineCount(t *testing.T, stableFor, timeout time.Duration) int {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	last := runtime.NumGoroutine()
+	stableSince := time.Now()
+	for time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+		now := runtime.NumGoroutine()
+		if now != last {
+			last = now
+			stableSince = time.Now()
+			continue
+		}
+		if time.Since(stableSince) >= stableFor {
+			return last
+		}
+	}
+	return last
 }
 
 func TestNewUsageService(t *testing.T) {
@@ -404,6 +431,11 @@ func TestUsageService_StartDailyResetMonitor(t *testing.T) {
 // StartPolling produces a working second polling loop. Regression test for the
 // race where the second goroutine could observe a closed stop channel and exit
 // before its first tick.
+//
+// To avoid the second-phase assertion being satisfied by a leaked first
+// goroutine, each phase uses its own callback/counter, and we confirm the
+// first phase's counter stops incrementing after StopPolling before starting
+// the second phase.
 func TestUsageService_PollingRestart(t *testing.T) {
 	service := newTestUsageService()
 	service.StopPolling()
@@ -424,55 +456,121 @@ func TestUsageService_PollingRestart(t *testing.T) {
 		[]byte("#!/bin/bash\necho '"+string(jsonData)+"'"), 0o755))
 	service.ccusagePath = scriptPath
 
-	var mu sync.Mutex
-	var calls int
-	cb := func(_ *models.UsageState) {
-		mu.Lock()
-		calls++
-		mu.Unlock()
+	makeCounter := func() (cb func(*models.UsageState), get func() int) {
+		var mu sync.Mutex
+		var n int
+		cb = func(_ *models.UsageState) {
+			mu.Lock()
+			n++
+			mu.Unlock()
+		}
+		get = func() int {
+			mu.Lock()
+			defer mu.Unlock()
+			return n
+		}
+		return
 	}
 
-	require.NoError(t, service.StartPolling(1, cb))
+	cb1, count1 := makeCounter()
+	require.NoError(t, service.StartPolling(1, cb1))
+	time.Sleep(1500 * time.Millisecond)
+	require.GreaterOrEqual(t, count1(), 1, "first polling loop should have fired before stop")
 	service.StopPolling()
 
-	require.NoError(t, service.StartPolling(1, cb))
+	// Confirm the first goroutine has actually stopped — no further callbacks
+	// for a brief settle window — so the second phase isn't satisfied by a
+	// leaked first loop.
+	frozen := count1()
+	time.Sleep(1200 * time.Millisecond)
+	require.Equal(t, frozen, count1(), "first polling loop should not fire after StopPolling")
+
+	cb2, count2 := makeCounter()
+	require.NoError(t, service.StartPolling(1, cb2))
 	defer service.StopPolling()
 
-	// Allow at least one tick from the restarted polling loop.
 	time.Sleep(1500 * time.Millisecond)
-
-	mu.Lock()
-	got := calls
-	mu.Unlock()
-	assert.GreaterOrEqual(t, got, 1, "restarted polling loop should fire at least once")
+	assert.GreaterOrEqual(t, count2(), 1, "restarted polling loop should fire at least once")
 }
 
 // TestUsageService_StopPollingTwice asserts that StopPolling is idempotent
 // even after channels have been swapped, guarding against double-close panics
-// in the channel-swap helper.
+// in the channel-swap helper. Also covers StopDailyResetMonitor for the same
+// reason.
 func TestUsageService_StopPollingTwice(t *testing.T) {
 	service := newTestUsageService()
 
 	require.NoError(t, service.StartPolling(1, nil))
 	service.StopPolling()
 	assert.NotPanics(t, func() { service.StopPolling() })
+
+	service.StartDailyResetMonitor()
+	service.StopDailyResetMonitor()
+	assert.NotPanics(t, func() { service.StopDailyResetMonitor() })
+}
+
+// TestUsageService_StartPollingDoesNotStopResetMonitor guards the bug where
+// StartPolling internally called StopPolling, and StopPolling closed both the
+// polling and reset channels — so restarting polling silently killed the
+// midnight monitor. Now StopPolling only touches the polling channel.
+func TestUsageService_StartPollingDoesNotStopResetMonitor(t *testing.T) {
+	service := newTestUsageService()
+	service.StopPolling()
+	service.StopDailyResetMonitor()
+
+	baseline := waitForStableGoroutineCount(t, 100*time.Millisecond, 1*time.Second)
+	service.StartDailyResetMonitor()
+	defer service.StopDailyResetMonitor()
+	require.Eventually(t, func() bool { return runtime.NumGoroutine() > baseline },
+		500*time.Millisecond, 10*time.Millisecond,
+		"reset monitor goroutine should be running")
+	withResetMonitor := runtime.NumGoroutine()
+
+	// Now (re)start polling. The reset monitor must survive.
+	require.NoError(t, service.StartPolling(1, nil))
+	defer service.StopPolling()
+
+	// Allow polling goroutine to spin up; we expect at least the reset monitor
+	// goroutine count to be retained, plus the new polling goroutine.
+	require.Eventually(t, func() bool { return runtime.NumGoroutine() >= withResetMonitor+1 },
+		500*time.Millisecond, 10*time.Millisecond,
+		"polling restart should not have killed the reset monitor goroutine")
 }
 
 // TestUsageService_DailyResetRestart verifies the daily reset monitor can be
-// stopped and restarted without deadlocking, exercising the same channel-swap
-// pattern as the polling loop.
+// stopped and restarted without deadlocking, and that the second start
+// actually launches a live goroutine. The dailyResetLoop has no externally
+// observable signal short of midnight, so liveness is asserted via the
+// runtime goroutine count rising above the idle baseline after a stop and
+// restart cycle — with a sleep after stop to let the first goroutine retire,
+// so the post-restart count would equal the idle baseline if the second
+// goroutine had observed a closed channel and exited immediately.
 func TestUsageService_DailyResetRestart(t *testing.T) {
 	service := newTestUsageService()
 	service.StopPolling()
+	service.StopDailyResetMonitor()
+
+	// Earlier tests can leave goroutines mid-exit; wait for the runtime to
+	// settle before sampling idle, otherwise idle is inflated by zombies that
+	// then retire mid-test and make our delta assertions look like regressions.
+	idle := waitForStableGoroutineCount(t, 100*time.Millisecond, 1*time.Second)
 
 	service.StartDailyResetMonitor()
-	service.StopPolling()
+	require.Eventually(t, func() bool { return runtime.NumGoroutine() > idle },
+		500*time.Millisecond, 10*time.Millisecond,
+		"first StartDailyResetMonitor should add a goroutine")
+
+	service.StopDailyResetMonitor()
+	// Give the first goroutine time to actually exit before we restart, so any
+	// elevated goroutine count after the second start is attributable to the
+	// second goroutine alone.
+	time.Sleep(150 * time.Millisecond)
 
 	service.StartDailyResetMonitor()
-	defer service.StopPolling()
-
-	// A short sleep is enough; we're checking lifecycle, not midnight detection.
-	time.Sleep(100 * time.Millisecond)
+	defer service.StopDailyResetMonitor()
+	require.Eventually(t, func() bool { return runtime.NumGoroutine() > idle },
+		500*time.Millisecond, 10*time.Millisecond,
+		"after stop+restart, goroutine count must exceed idle — proves the restarted loop didn't observe a closed channel and exit immediately")
 }
 
 func TestUsageService_UpdateWithRetry_NotAvailable(t *testing.T) {

--- a/src/services/usage_service_test.go
+++ b/src/services/usage_service_test.go
@@ -400,6 +400,81 @@ func TestUsageService_StartDailyResetMonitor(t *testing.T) {
 	service.StopPolling()
 }
 
+// TestUsageService_PollingRestart verifies that StartPolling -> StopPolling ->
+// StartPolling produces a working second polling loop. Regression test for the
+// race where the second goroutine could observe a closed stop channel and exit
+// before its first tick.
+func TestUsageService_PollingRestart(t *testing.T) {
+	service := newTestUsageService()
+	service.StopPolling()
+
+	// Point ccusage at a fast shim so updateWithRetry returns immediately and
+	// the callback fires within the test's wait window.
+	tempDir := t.TempDir()
+	scriptPath := filepath.Join(tempDir, "fake-ccusage")
+	today := time.Now().Format("2006-01-02")
+	resp := CCUsageResponse{
+		Daily: []CCUsageOutput{{Date: today, TotalTokens: 1, TotalCost: 0.01}},
+	}
+	resp.Totals.TotalTokens = 1
+	resp.Totals.TotalCost = 0.01
+	jsonData, err := json.Marshal(resp)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(scriptPath,
+		[]byte("#!/bin/bash\necho '"+string(jsonData)+"'"), 0o755))
+	service.ccusagePath = scriptPath
+
+	var mu sync.Mutex
+	var calls int
+	cb := func(_ *models.UsageState) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+	}
+
+	require.NoError(t, service.StartPolling(1, cb))
+	service.StopPolling()
+
+	require.NoError(t, service.StartPolling(1, cb))
+	defer service.StopPolling()
+
+	// Allow at least one tick from the restarted polling loop.
+	time.Sleep(1500 * time.Millisecond)
+
+	mu.Lock()
+	got := calls
+	mu.Unlock()
+	assert.GreaterOrEqual(t, got, 1, "restarted polling loop should fire at least once")
+}
+
+// TestUsageService_StopPollingTwice asserts that StopPolling is idempotent
+// even after channels have been swapped, guarding against double-close panics
+// in the channel-swap helper.
+func TestUsageService_StopPollingTwice(t *testing.T) {
+	service := newTestUsageService()
+
+	require.NoError(t, service.StartPolling(1, nil))
+	service.StopPolling()
+	assert.NotPanics(t, func() { service.StopPolling() })
+}
+
+// TestUsageService_DailyResetRestart verifies the daily reset monitor can be
+// stopped and restarted without deadlocking, exercising the same channel-swap
+// pattern as the polling loop.
+func TestUsageService_DailyResetRestart(t *testing.T) {
+	service := newTestUsageService()
+	service.StopPolling()
+
+	service.StartDailyResetMonitor()
+	service.StopPolling()
+
+	service.StartDailyResetMonitor()
+	defer service.StopPolling()
+
+	// A short sleep is enough; we're checking lifecycle, not midnight detection.
+	time.Sleep(100 * time.Millisecond)
+}
+
 func TestUsageService_UpdateWithRetry_NotAvailable(t *testing.T) {
 	service := newTestUsageService()
 


### PR DESCRIPTION
## Summary
- Fix a race where `StopPolling` could close the polling stop channel before the goroutine started, leaving the loop running until the next interval. Polling goroutines are now launched under the service mutex so the captured stop channel can't be swapped out before the loop observes it.
- Split shutdown into `StopPolling` (polling loop only) and `StopDailyResetMonitor` (midnight reset loop only). Previously a polling restart killed the midnight monitor as a side effect.
- Deduplicate stop-channel swap logic into a shared helper.
- Strengthen lifecycle tests: per-phase counters in the polling-restart test, goroutine-delta liveness checks for the reset-monitor restart, idempotency coverage for both stop functions, and a regression test asserting `StopPolling` no longer stops the reset monitor.

## Test plan
- [x] `go test ./...` passes (services suite covers all new lifecycle assertions)
- [ ] Manual smoke: run the tray app, confirm graceful shutdown on SIGTERM closes both polling and reset-monitor goroutines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * App now reliably stops all background monitoring during shutdown and when restarting monitors, preventing resource/goroutine leaks and ensuring clean exits.

* **Tests**
  * Added regression tests to verify polling and daily-reset monitors can be started, stopped, and restarted safely without leaking goroutines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/petems/cc-dailyuse-bar/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->